### PR TITLE
Generalize schema for arbitrary payload specifications

### DIFF
--- a/schema/device.json
+++ b/schema/device.json
@@ -58,7 +58,6 @@
                     "description": "Specifies a summary description of the bit mask function.",
                     "type": "string"
                 },
-                "payloadType": { "$ref": "#/definitions/payloadType" },
                 "bits": {
                     "type": "object",
                     "additionalProperties": { "type": "integer" }

--- a/schema/device.json
+++ b/schema/device.json
@@ -80,6 +80,7 @@
                 "address": {
                     "description": "Specifies the unique 8-bit address of the register.",
                     "type": "integer",
+                    "minimum": 32,
                     "maximum": 255
                 },
                 "registerType": {

--- a/schema/device.json
+++ b/schema/device.json
@@ -28,15 +28,15 @@
             "type": "array",
             "items": { "$ref": "#/definitions/register" }
         },
-        "masks": {
+        "bitMasks": {
+            "type": "object",
             "description": "Specifies the collection of masks available to be used with the different registers.",
-            "type": "array",
-            "items": { "$ref": "#/definitions/bitMask" }
+            "additionalProperties": { "$ref": "#/definitions/bitMask" }
         },
         "ios": {
+            "type": "object",
             "description": "Specifies the IO pin configuration used to automatically generate the firmware.",
-            "type": "array",
-            "items": { "$ref": "#/definitions/pin" }
+            "additionalProperties": { "$ref": "#/definitions/pin" }
         }
     },
     "required": ["device", "whoAmI", "firmwareVersion", "hardwareTargets", "registers"],
@@ -50,10 +50,6 @@
             "description": "Specifies a bit mask used for reading or writing specific registers.",
             "type": "object",
             "properties": {
-                "name": {
-                    "description": "Specifies the unique name of the bit mask.",
-                    "type": "string"
-                },
                 "description": {
                     "description": "Specifies a summary description of the bit mask function.",
                     "type": "string"
@@ -63,7 +59,7 @@
                     "additionalProperties": { "type": "integer" }
                 }
             },
-            "required": ["name", "payloadType"]
+            "required": ["bits"]
         },
         "register": {
             "type": "object",
@@ -124,10 +120,6 @@
         "pin": {
             "type": "object",
             "properties": {
-                "name": {
-                    "description":"Specifies the unique name of the IO pin.",
-                    "type": "string"
-                },
                 "description": {
                     "description": "Specifies a summary description of the IO function.",
                     "type": "string"

--- a/schema/device.json
+++ b/schema/device.json
@@ -129,7 +129,8 @@
                 "payloadType": { "$ref": "#/definitions/payloadType" },
                 "payloadLength": {
                     "description": "Specifies the length of the register payload.",
-                    "type": "integer"
+                    "type": "integer",
+                    "minimum": 1
                 },
                 "payloadSpec": {
                     "type": "object",

--- a/schema/device.json
+++ b/schema/device.json
@@ -129,15 +129,16 @@
                     "type": "integer"
                 },
                 "payloadSpec": {
-                    "oneOf": [
-                        {
-                            "$ref": "#/definitions/payloadMember"
-                        },
-                        {
-                            "type": "object",
-                            "additionalProperties": { "$ref": "#/definitions/payloadMember" }
-                        }
-                    ]
+                    "type": "object",
+                    "additionalProperties": { "$ref": "#/definitions/payloadMember" }
+                },
+                "maskType": {
+                    "description": "Specifies the name of the bit mask or group mask used to represent the payload data.",
+                    "type": "string"
+                },
+                "converter": {
+                    "description": "Flags the existence of an optional converter method used to parse or format the payload value in the high-level interface.",
+                    "type": "boolean"
                 },
                 "visibility": {
                     "description": "Specifies whether the register function is exposed in the high-level interface.",

--- a/schema/device.json
+++ b/schema/device.json
@@ -83,6 +83,7 @@
         },
         "payloadMember": {
             "type": "object",
+            "additionalProperties": false,
             "properties": {
                 "mask": {
                     "description": "Specifies the mask used to read and write this payload member.",

--- a/schema/device.json
+++ b/schema/device.json
@@ -59,13 +59,12 @@
                     "description": "Specifies a summary description of the bit mask function.",
                     "type": "string"
                 },
-                "payloadType": { "$ref": "#/definitions/payloadType" },
                 "bits": {
                     "type": "object",
                     "additionalProperties": { "type": "integer" }
                 }
             },
-            "required": ["payloadType", "bits"]
+            "required": ["bits"]
         },
         "groupMask": {
             "description": "Specifies a group mask used for reading or writing specific registers.",
@@ -75,13 +74,12 @@
                     "description": "Specifies a summary description of the group mask function.",
                     "type": "string"
                 },
-                "payloadType": { "$ref": "#/definitions/payloadType" },
                 "values": {
                     "type": "object",
                     "additionalProperties": { "type": "integer" }
                 }
             },
-            "required": ["payloadType", "values"]
+            "required": ["values"]
         },
         "payloadMember": {
             "type": "object",

--- a/schema/device.json
+++ b/schema/device.json
@@ -133,7 +133,7 @@
                     "description": "Specifies a summary description of the IO function.",
                     "type": "string"
                 },
-                "port": {
+                "portName": {
                     "description": "Specifies the microcontroller port.",
                     "type": "string"
                 },
@@ -167,13 +167,13 @@
                 },
                 "interruptNumber":{
                     "description": "Specifies the interrupt number associated with the specific pin.",
-                    "type": "string",
-                    "enum": ["INT0", "INT1"]
+                    "type": "integer",
+                    "enum": [0, 1]
                 },
                 "out":{
                     "description": "ONLY OUTPUTS. Specifies output mode of the pin.",
                     "type": "string",
-                    "enum": ["digital", "wire_or", "wire_and", "wired_or_pull", "wired_and_pull"]
+                    "enum": ["digital", "wireOr", "wireAnd", "wiredOrPull", "wiredAndPull"]
                 },
                 "outDefault":{
                     "description": "Specifies the initial state of the output line at boot time.",
@@ -184,7 +184,7 @@
                     "type": "boolean"
                 }
             },
-            "required": ["name", "port", "pin", "direction"]
+            "required": ["portName", "pinNumber", "direction"]
         }
     }
 }

--- a/schema/device.json
+++ b/schema/device.json
@@ -41,7 +41,7 @@
         "ios": {
             "type": "object",
             "description": "Specifies the IO pin configuration used to automatically generate the firmware.",
-            "additionalProperties": { "$ref": "#/definitions/pin" }
+            "additionalProperties": { "$ref": "#/definitions/pinMapping" }
         }
     },
     "required": ["device", "whoAmI", "firmwareVersion", "hardwareTargets", "registers"],
@@ -155,18 +155,18 @@
             },
             "required": ["address", "registerType", "payloadType"]
         },
-        "pin": {
+        "pinMapping": {
             "type": "object",
             "properties": {
                 "description": {
                     "description": "Specifies a summary description of the IO function.",
                     "type": "string"
                 },
-                "portName": {
+                "port": {
                     "description": "Specifies the microcontroller port.",
                     "type": "string"
                 },
-                "pinNumber": {
+                "pin": {
                     "description": "Specifies the unique pin number in the defined port.",
                     "type": "integer"
                 },
@@ -213,7 +213,7 @@
                     "type": "boolean"
                 }
             },
-            "required": ["portName", "pinNumber", "direction"]
+            "required": ["port", "pin", "direction"]
         }
     }
 }

--- a/schema/device.json
+++ b/schema/device.json
@@ -24,9 +24,9 @@
             "type": "string"
         },
         "registers": {
+            "type": "object",
             "description": "Specifies the collection of registers implementing the device function.",
-            "type": "array",
-            "items": { "$ref": "#/definitions/register" }
+            "additionalProperties": { "$ref": "#/definitions/register" }
         },
         "bitMasks": {
             "type": "object",
@@ -105,10 +105,6 @@
         "register": {
             "type": "object",
             "properties": {
-                "name": {
-                    "description":"Specifies the unique name of the register.",
-                    "type": "string"
-                },
                 "description": {
                     "description": "Specifies a summary description of the register function.",
                     "type": "string"
@@ -150,7 +146,7 @@
                     "type": "string"
                 }
             },
-            "required": ["name", "address", "registerType", "payloadType"]
+            "required": ["address", "registerType", "payloadType"]
         },
         "pin": {
             "type": "object",

--- a/schema/device.json
+++ b/schema/device.json
@@ -33,6 +33,11 @@
             "description": "Specifies the collection of masks available to be used with the different registers.",
             "additionalProperties": { "$ref": "#/definitions/bitMask" }
         },
+        "groupMasks": {
+            "type": "object",
+            "description": "Specifies the collection of group masks available to be used with the different registers.",
+            "additionalProperties": { "$ref": "#/definitions/groupMask" }
+        },
         "ios": {
             "type": "object",
             "description": "Specifies the IO pin configuration used to automatically generate the firmware.",
@@ -60,6 +65,21 @@
                 }
             },
             "required": ["bits"]
+        },
+        "groupMask": {
+            "description": "Specifies a group mask used for reading or writing specific registers.",
+            "type": "object",
+            "properties": {
+                "description": {
+                    "description": "Specifies a summary description of the group mask function.",
+                    "type": "string"
+                },
+                "values": {
+                    "type": "object",
+                    "additionalProperties": { "type": "integer" }
+                }
+            },
+            "required": ["values"]
         },
         "register": {
             "type": "object",

--- a/schema/device.json
+++ b/schema/device.json
@@ -59,12 +59,13 @@
                     "description": "Specifies a summary description of the bit mask function.",
                     "type": "string"
                 },
+                "payloadType": { "$ref": "#/definitions/payloadType" },
                 "bits": {
                     "type": "object",
                     "additionalProperties": { "type": "integer" }
                 }
             },
-            "required": ["bits"]
+            "required": ["payloadType", "bits"]
         },
         "groupMask": {
             "description": "Specifies a group mask used for reading or writing specific registers.",
@@ -74,12 +75,13 @@
                     "description": "Specifies a summary description of the group mask function.",
                     "type": "string"
                 },
+                "payloadType": { "$ref": "#/definitions/payloadType" },
                 "values": {
                     "type": "object",
                     "additionalProperties": { "type": "integer" }
                 }
             },
-            "required": ["values"]
+            "required": ["payloadType", "values"]
         },
         "payloadMember": {
             "type": "object",

--- a/schema/device.json
+++ b/schema/device.json
@@ -81,6 +81,27 @@
             },
             "required": ["values"]
         },
+        "payloadMember": {
+            "type": "object",
+            "properties": {
+                "mask": {
+                    "description": "Specifies the mask used to read and write this payload member.",
+                    "type": "integer"
+                },
+                "offset": {
+                    "description": "Specifies the payload array offset where this payload member is stored.",
+                    "type": "integer"
+                },
+                "maskType": {
+                    "description": "Specifies the name of the bit mask or group mask used to represent the payload data.",
+                    "type": "string"
+                },
+                "converter": {
+                    "description": "Flags the existence of an optional converter method used to parse or format the payload value in the high-level interface.",
+                    "type": "boolean"
+                }
+            }
+        },
         "register": {
             "type": "object",
             "properties": {
@@ -104,26 +125,20 @@
                     "enum": ["Command", "Event", "Both"]
                 },
                 "payloadType": { "$ref": "#/definitions/payloadType" },
-                "arrayType": {
-                    "description": "Specifies the optional array format for the register payload.",
+                "payloadLength": {
+                    "description": "Specifies the length of the register payload.",
+                    "type": "integer"
+                },
+                "payloadSpec": {
                     "oneOf": [
                         {
-                            "type": "array",
-                            "items": {
-                                "type": "string"
-                            }
+                            "$ref": "#/definitions/payloadMember"
                         },
                         {
-                            "type": "integer"
+                            "type": "object",
+                            "additionalProperties": { "$ref": "#/definitions/payloadMember" }
                         }
                     ]
-                },
-                "maskType": {
-                    "$ref": "#/definitions/bitMask/properties/name"
-                },
-                "converter": {
-                    "description": "Flags the existence of an optional converter method used to parse or format the mask value in the high-level interface.",
-                    "type": "boolean"
                 },
                 "visibility": {
                     "description": "Specifies whether the register function is exposed in the high-level interface.",

--- a/schema/device.json
+++ b/schema/device.json
@@ -85,8 +85,11 @@
         },
         "payloadMember": {
             "type": "object",
-            "additionalProperties": false,
             "properties": {
+                "description": {
+                    "description": "Specifies a summary description of the payload member.",
+                    "type": "string"
+                },
                 "mask": {
                     "description": "Specifies the mask used to read and write this payload member.",
                     "type": "integer"

--- a/schema/example.yml
+++ b/schema/example.yml
@@ -2,75 +2,74 @@
 device: ExampleDevice
 whoAmI: 0000
 firmwareVersion: "0.1"
-hardwareVersion: "0.1"
+hardwareTargets: "0.1"
 architecture: "atmega"
 registers:
-  - name: Cam0Event
+  Cam0Event:
     address: 32
     payloadType: U8
     registerType: Event
-  - name: Cam0TriggerFrequency
+  Cam0TriggerFrequency:
     address: 33
     registerType: Command
     payloadType: U16
     maskType: DO
     description: Sets the trigger frequency for camera 0 between 1 and 1000.
-  - name: Cam0TriggerDuration
+  Cam0TriggerDuration:
     address: 34
     registerType: Command
     payloadType: U16
     description: Sets the duration of the trigger pulse (minimum is 100) for camera 0.
-  - name: StartAndStop
+  StartAndStop:
     address: 35
     registerType: Command
     payloadType: U8
     description: Starts or stops the camera immediately.
-  - name: InState
+  InState:
     address: 36
     registerType: Event
     payloadType: U8
     description: Contains the state of the input ports.
-  - name: Valve0Pulse
+  Valve0Pulse:
     address: 37
     registerType: Command
     payloadType: U8
     description: Configures the valve 0 open time in milliseconds.
-  - name: OutSet
+  OutSet:
     address: 38
     registerType: Command
     payloadType: U8
     description: Bitmask to set the available outputs.
-  - name: OutClear
+  OutClear:
     address: 39
     registerType: Command
     payloadType: U8
     description: Bitmask to clear the available outputs.
-  - name: OutToggle
+  OutToggle:
     address: 40
     registerType: Command
     payloadType: U8
     description: Bitmask to toggle the available outputs.
-  - name: OutWrite
+  OutWrite:
     address: 41
     registerType: Command
     payloadType: U8
     maskType: DO
     description: Bitmask to write the available outputs.
-masks:
-  - name: DO
-    payloadType: U8
+bitMasks:
+  DO:
     description: Bitmask representing the state of the digital outputs.
     bits:
       DO0: 0x01
       DO1: 0x02
 ios:
-  - name: DO3
-    port: PORTC
-    pin: 0
+  DO3:
+    portName: PORTC
+    pinNumber: 0
     direction: output
     description: DO0
-  - name: DO2
-    port: PORTB
-    pin: 2
+  DO2:
+    portName: PORTB
+    pinNumber: 2
     direction: output
     description: DO0

--- a/schema/example.yml
+++ b/schema/example.yml
@@ -59,7 +59,6 @@ registers:
 bitMasks:
   DO:
     description: Bitmask representing the state of the digital outputs.
-    payloadType: U8
     bits:
       DO0: 0x01
       DO1: 0x02

--- a/schema/example.yml
+++ b/schema/example.yml
@@ -59,6 +59,7 @@ registers:
 bitMasks:
   DO:
     description: Bitmask representing the state of the digital outputs.
+    payloadType: U8
     bits:
       DO0: 0x01
       DO1: 0x02

--- a/schema/example.yml
+++ b/schema/example.yml
@@ -65,12 +65,12 @@ bitMasks:
       DO1: 0x02
 ios:
   DO3:
-    portName: PORTC
-    pinNumber: 0
+    port: PORTC
+    pin: 0
     direction: output
     description: DO0
   DO2:
-    portName: PORTB
-    pinNumber: 2
+    port: PORTB
+    pin: 2
     direction: output
     description: DO0


### PR DESCRIPTION
This PR generalizes the schema to allow specifying arbitrary payload types. There are several use cases for custom payload types:

1. The payload is a compound collection of bitmasks, e.g. the [R_OPERATION_CTRL](https://harp-tech.org/About/How-HARP-works/common_registers_operation_devices.html#r-operation-ctrl-configuration-the-operation-mode) register;
2. The payload is a named array of values, e.g. the pair of ADC and Encoder readings in the Behavior board;
3. The payload is a compound type of bitmasks and a value, e.g. a 12-bit ADC value with a 4-bit flags packed into a 16-bit register.

This requires increased flexibility but, assuming all cases fall into either array indexing or bitmask payload extraction, it is possible to automate and has the potential to be applicable to a wide range of boards.

The PR also refactors the schema to prefer the use of mappings rather than sequences. The advantage is that mappings translate directly to a dictionary of unique keys, so avoids having to deal with redundant/conflicting entries, and translates into a more compact description in most cases.