### PR TITLE
Add text templates for automatic interface generation

### DIFF
--- a/interface/Device.tt
+++ b/interface/Device.tt
@@ -127,7 +127,7 @@ foreach (var register in eventMetadata)
 foreach (var registerMetadata in eventMetadata)
 {
     var register = registerMetadata.Value;
-    var payloadSuffix = register.PayloadTypeSuffix;
+    var payloadSuffix = Converter.GetPayloadTypeSuffix(register.PayloadType, register.PayloadLength);
     var payloadSelector = $"input.GetPayload{payloadSuffix}()";
     var interfaceType = Converter.GetInterfaceType(registerMetadata.Key, register);
     var conversion = Converter.GetEventConversion(register, payloadSelector);
@@ -217,9 +217,9 @@ foreach (var register in commandMetadata)
 foreach (var registerMetadata in commandMetadata)
 {
     var register = registerMetadata.Value;
-    var payloadSuffix = register.PayloadTypeSuffix;
+    var payloadSuffix = Converter.GetPayloadTypeSuffix(register.PayloadType);
     var interfaceType = Converter.GetInterfaceType(registerMetadata.Key, register);
-    var conversion = !string.IsNullOrEmpty(register.MaskType) ? $"({Converter.GetInterfaceType(register.PayloadType)})" : string.Empty;
+    var conversion = Converter.GetCommandConversion(register, "input");
     var summaryDescription = string.IsNullOrEmpty(register.Description)
         ? $"to write on register {registerMetadata.Key}"
         : $"that {char.ToLower(register.Description[0])}{register.Description.Substring(1).TrimEnd('.')}";
@@ -232,10 +232,47 @@ foreach (var registerMetadata in commandMetadata)
     [DesignTimeVisible(false)]
     [Description("Creates a sequence of command messages <#= summaryDescription #>.")]
     public partial class <#= registerMetadata.Key #> : Combinator<<#= interfaceType #>, HarpMessage>
+    {<#
+    if (register.PayloadSpec != null)
     {
+#>
+
+        static <#= register.PayloadInterfaceType #> Format(<#= interfaceType #> value)
+        {
+            <#= register.PayloadInterfaceType #> result;
+<#
+        if (register.PayloadLength > 0)
+        {
+#>
+            result = new <#= Converter.GetInterfaceType(register.PayloadType) #>[<#= register.PayloadLength #>];
+<#
+        }
+#>
+<#
+        var assigned = new bool[Math.Max(1, register.PayloadLength)];
+        foreach (var member in register.PayloadSpec)
+        {
+            var payloadIndex = member.Value.Offset.GetValueOrDefault(0);
+            var memberIndexer = member.Value.Offset.HasValue ? $"[{member.Value.Offset}]" : string.Empty;
+            var memberConversion = Converter.GetPayloadMemberFormatter(
+                member.Value,
+                $"value.{member.Key}",
+                register.PayloadType,
+                assigned[payloadIndex]);
+            assigned[payloadIndex] = true;
+#>
+            result<#= memberIndexer #><#= memberConversion #>;
+<#
+        }
+#>
+            return result;
+        }
+<#
+    }#>
+
         public override IObservable<HarpMessage> Process(IObservable<<#= interfaceType #>> source)
         {
-            return source.Select(input => HarpCommand.Write<#= payloadSuffix #>(address: <#= register.Address #>, <#= conversion #>input));
+            return source.Select(input => HarpCommand.Write<#= payloadSuffix #>(address: <#= register.Address #>, <#= conversion #>));
         }
     }
 <#

--- a/interface/Device.tt
+++ b/interface/Device.tt
@@ -25,8 +25,9 @@ using (var reader = new StreamReader(metadataFileName))
         .Build();
 
     deviceMetadata = deserializer.Deserialize<DeviceInfo>(reader);
-    eventMetadata = deviceMetadata.Registers.Where(register => register.Value.RegisterType == RegisterType.Event);
-    commandMetadata = deviceMetadata.Registers.Where(register => register.Value.RegisterType == RegisterType.Command);
+    var publicRegisters = deviceMetadata.Registers.Where(register => register.Value.Visibility == RegisterVisibility.Public);
+    eventMetadata = publicRegisters.Where(register => register.Value.RegisterType == RegisterType.Event);
+    commandMetadata = publicRegisters.Where(register => register.Value.RegisterType == RegisterType.Command);
 }
 
 var deviceName = deviceMetadata.Device;

--- a/interface/Device.tt
+++ b/interface/Device.tt
@@ -15,8 +15,8 @@ var path = Host.ResolvePath(string.Empty);
 var namespaceName = Path.GetFileName(path);
 
 DeviceInfo deviceMetadata;
-IEnumerable<RegisterInfo> eventMetadata;
-IEnumerable<RegisterInfo> commandMetadata;
+IEnumerable<KeyValuePair<string, RegisterInfo>> eventMetadata;
+IEnumerable<KeyValuePair<string, RegisterInfo>> commandMetadata;
 var metadataFileName = Host.ResolvePath("../../../Firmware/VestibularH1/registers.yml");
 using (var reader = new StreamReader(metadataFileName))
 {
@@ -25,8 +25,8 @@ using (var reader = new StreamReader(metadataFileName))
         .Build();
 
     deviceMetadata = deserializer.Deserialize<DeviceInfo>(reader);
-    eventMetadata = deviceMetadata.Registers.Where(register => register.RegisterType == RegisterType.Event);
-    commandMetadata = deviceMetadata.Registers.Where(register => register.RegisterType == RegisterType.Command);
+    eventMetadata = deviceMetadata.Registers.Where(register => register.Value.RegisterType == RegisterType.Event);
+    commandMetadata = deviceMetadata.Registers.Where(register => register.Value.RegisterType == RegisterType.Command);
 }
 
 var deviceName = deviceMetadata.Device;
@@ -100,7 +100,7 @@ namespace <#= namespaceName #>
 foreach (var register in eventMetadata)
 {
 #>
-    /// <seealso cref="<#= register.Name #>"/>
+    /// <seealso cref="<#= register.Key #>"/>
 <#
 }
 #>
@@ -108,7 +108,7 @@ foreach (var register in eventMetadata)
 foreach (var register in eventMetadata)
 {
 #>
-    [XmlInclude(typeof(<#= register.Name #>))]
+    [XmlInclude(typeof(<#= register.Key #>))]
 <#
 }
 #>
@@ -119,17 +119,19 @@ foreach (var register in eventMetadata)
         /// </summary>
         public <#= eventClassName #>()
         {
-            Event = new <#= eventMetadata.First().Name #>();
+            Event = new <#= eventMetadata.First().Key #>();
         }
     }
 <#
-foreach (var register in eventMetadata)
+foreach (var registerMetadata in eventMetadata)
 {
-    var interfaceType = register.InterfaceType;
+    var register = registerMetadata.Value;
     var payloadSuffix = register.PayloadTypeSuffix;
-    var conversion = !string.IsNullOrEmpty(register.MaskType) ? $"({register.MaskType})" : string.Empty;
+    var payloadSelector = $"input.GetPayload{payloadSuffix}()";
+    var interfaceType = Converter.GetInterfaceType(registerMetadata.Key, register);
+    var conversion = Converter.GetEventConversion(register, payloadSelector);
     var summaryDescription = string.IsNullOrEmpty(register.Description)
-        ? $"from register {register.Name}"
+        ? $"from register {registerMetadata.Key}"
         : $"that {char.ToLower(register.Description[0])}{register.Description.Substring(1).TrimEnd('.')}";
 #>
 
@@ -139,7 +141,7 @@ foreach (var register in eventMetadata)
     /// </summary>
     [DesignTimeVisible(false)]
     [Description("Filters and selects a sequence of event messages <#= summaryDescription #>.")]
-    public partial class <#= register.Name #> : Combinator<HarpMessage, <#= interfaceType #>>
+    public partial class <#= registerMetadata.Key #> : Combinator<HarpMessage, <#= interfaceType #>>
     {
         /// <summary>
         /// Filters and selects an observable sequence of event messages
@@ -152,7 +154,7 @@ foreach (var register in eventMetadata)
         /// </returns>
         public override IObservable<<#= interfaceType #>> Process(IObservable<HarpMessage> source)
         {
-            return source.Event(address: <#= register.Address #>).Select(input => <#= conversion #>input.GetPayload<#= payloadSuffix #>());
+            return source.Event(address: <#= register.Address #>).Select(input => <#= conversion #>);
         }
     }
 <#
@@ -167,7 +169,7 @@ foreach (var register in eventMetadata)
 foreach (var register in commandMetadata)
 {
 #>
-    /// <seealso cref="<#= register.Name #>"/>
+    /// <seealso cref="<#= register.Key #>"/>
 <#
 }
 #>
@@ -175,7 +177,7 @@ foreach (var register in commandMetadata)
 foreach (var register in commandMetadata)
 {
 #>
-    [XmlInclude(typeof(<#= register.Name #>))]
+    [XmlInclude(typeof(<#= register.Key #>))]
 <#
 }
 #>
@@ -186,17 +188,18 @@ foreach (var register in commandMetadata)
         /// </summary>
         public <#= commandClassName #>()
         {
-            Command = new <#= commandMetadata.First().Name #>();
+            Command = new <#= commandMetadata.First().Key #>();
         }
     }
 <#
-foreach (var register in commandMetadata)
+foreach (var registerMetadata in commandMetadata)
 {
-    var interfaceType = register.InterfaceType;
+    var register = registerMetadata.Value;
     var payloadSuffix = register.PayloadTypeSuffix;
+    var interfaceType = Converter.GetInterfaceType(registerMetadata.Key, register);
     var conversion = !string.IsNullOrEmpty(register.MaskType) ? $"({Converter.GetInterfaceType(register.PayloadType)})" : string.Empty;
     var summaryDescription = string.IsNullOrEmpty(register.Description)
-        ? $"to write on register {register.Name}"
+        ? $"to write on register {registerMetadata.Key}"
         : $"that {char.ToLower(register.Description[0])}{register.Description.Substring(1).TrimEnd('.')}";
 #>
 
@@ -206,7 +209,7 @@ foreach (var register in commandMetadata)
     /// </summary>
     [DesignTimeVisible(false)]
     [Description("Creates a sequence of command messages <#= summaryDescription #>.")]
-    public partial class <#= register.Name #> : Combinator<<#= interfaceType #>, HarpMessage>
+    public partial class <#= registerMetadata.Key #> : Combinator<<#= interfaceType #>, HarpMessage>
     {
         public override IObservable<HarpMessage> Process(IObservable<<#= interfaceType #>> source)
         {
@@ -217,15 +220,44 @@ foreach (var register in commandMetadata)
 }
 #>
 <#
-foreach (var mask in deviceMetadata.Masks)
+foreach (var registerMetadata in deviceMetadata.Registers)
 {
+    var register = registerMetadata.Value;
+    if (register.PayloadSpec == null) continue;
+#>
+
+    /// <summary>
+    /// Represents the payload of the <#= registerMetadata.Key #> register.
+    /// </summary>
+    public struct <#= registerMetadata.Key #>Payload
+    {<#
+    foreach (var member in register.PayloadSpec)
+    {
+        var memberType = string.IsNullOrEmpty(member.Value.MaskType) ? Converter.GetInterfaceType(register.PayloadType) : member.Value.MaskType;
+#>
+
+        /// <summary>
+        /// <#= member.Value.Description #>
+        /// </summary>
+        public <#= memberType #> <#= member.Key #>;
+<#
+    }
+#>
+    }
+<#
+}
+#>
+<#
+foreach (var bitMask in deviceMetadata.BitMasks)
+{
+    var mask = bitMask.Value;
 #>
 
     /// <summary>
     /// <#= mask.Description #>
     /// </summary>
     [Flags]
-    public enum <#= mask.Name #> : <#= mask.InterfaceType #>
+    public enum <#= bitMask.Key #> : <#= mask.InterfaceType #>
     {
 <#
     var bitIndex = 0;
@@ -233,6 +265,30 @@ foreach (var mask in deviceMetadata.Masks)
     {
 #>
         <#= bitField.Key #> = 0x<#= bitField.Value.ToString("X") #><#= ++bitIndex < mask.Bits.Count ? "," : string.Empty #>
+<#
+    }
+#>
+    }
+<#
+}
+#>
+<#
+foreach (var groupMask in deviceMetadata.GroupMasks)
+{
+    var mask = groupMask.Value;
+#>
+
+    /// <summary>
+    /// <#= mask.Description #>
+    /// </summary>
+    public enum <#= groupMask.Key #> : <#= mask.InterfaceType #>
+    {
+<#
+    var memberIndex = 0;
+    foreach (var member in mask.Values)
+    {
+#>
+        <#= member.Key #> = <#= member.Value #><#= ++memberIndex < mask.Values.Count ? "," : string.Empty #>
 <#
     }
 #>

--- a/interface/Device.tt
+++ b/interface/Device.tt
@@ -1,0 +1,243 @@
+﻿<#@ template debug="false" hostspecific="true" language="C#" #>
+<#@ assembly name="System.Core" #>
+<#@ import namespace="System.IO" #>
+<#@ import namespace="System.Linq" #>
+<#@ import namespace="System.Text" #>
+<#@ import namespace="System.Collections.Generic" #>
+<#@ assembly name="$(PkgYamlDotNet)\\lib\\net47\\YamlDotNet.dll" #>
+<#@ import namespace="YamlDotNet" #>
+<#@ import namespace="YamlDotNet.Serialization" #>
+<#@ import namespace="YamlDotNet.Serialization.NamingConventions" #>
+<#@ include file="Harp.tt" #><##>
+<#@ output extension=".cs" #>
+<#
+var path = Host.ResolvePath(string.Empty);
+var namespaceName = Path.GetFileName(path);
+
+DeviceInfo deviceMetadata;
+IEnumerable<RegisterInfo> eventMetadata;
+IEnumerable<RegisterInfo> commandMetadata;
+var metadataFileName = Host.ResolvePath("../../../Firmware/VestibularH1/registers.yml");
+using (var reader = new StreamReader(metadataFileName))
+{
+    var deserializer = new DeserializerBuilder()
+        .WithNamingConvention(CamelCaseNamingConvention.Instance)
+        .Build();
+
+    deviceMetadata = deserializer.Deserialize<DeviceInfo>(reader);
+    eventMetadata = deviceMetadata.Registers.Where(register => register.RegisterType == RegisterType.Event);
+    commandMetadata = deviceMetadata.Registers.Where(register => register.RegisterType == RegisterType.Command);
+}
+
+var deviceName = deviceMetadata.Device;
+var deviceClassName = deviceName + "Device";
+var eventClassName = deviceName + "Event";
+var commandClassName = deviceName + "Command";
+#>
+<#
+foreach (var ns in Host.StandardImports)
+{
+    Write("using " + ns + ";");
+}
+#>
+
+using System.ComponentModel;
+using System.Reactive.Linq;
+using System.Xml.Serialization;
+
+namespace <#= namespaceName #>
+{
+    /// <summary>
+    /// Represents an observable source of messages from the <#= deviceName #> device connected
+    /// at the specified serial port.
+    /// </summary>
+    [Combinator(MethodName = nameof(Generate))]
+    [WorkflowElementCategory(ElementCategory.Source)]
+    [Description("Generates events and processes commands for the <#= deviceName #> device.")]
+    public partial class <#= deviceClassName #>
+    {
+        readonly Device device = new Device(whoAmI: <#= deviceMetadata.WhoAmI #>);
+
+        /// <summary>
+        /// Gets or sets the name of the serial port used to communicate with the
+        /// <#= deviceName #> device.
+        /// </summary>
+        [TypeConverter(typeof(PortNameConverter))]
+        [Description("The name of the serial port used to communicate with the <#= deviceName #> device.")]
+        public string PortName
+        {
+            get { return device.PortName; }
+            set { device.PortName = value; }
+        }
+
+        /// <summary>
+        /// Connects to the specified serial port and returns an observable sequence of Harp messages
+        /// coming from the device.
+        /// </summary>
+        /// <returns>The observable sequence of Harp messages produced by the device.</returns>
+        public IObservable<HarpMessage> Generate()
+        {
+            return Generate(Observable.Empty<HarpMessage>());
+        }
+
+        /// <summary>
+        /// Connects to the specified serial port and sends the observable sequence of Harp messages.
+        /// The return value is an observable sequence of Harp messages coming from the device.
+        /// </summary>
+        /// <param name="source">An observable sequence of Harp messages to send to the device.</param>
+        /// <returns>The observable sequence of Harp messages produced by the device.</returns>
+        public IObservable<HarpMessage> Generate(IObservable<HarpMessage> source)
+        {
+            return device.Generate(source);
+        }
+    }
+
+    /// <summary>
+    /// Represents an operator which filters and selects specific event messages
+    /// reported by the Harp device.
+    /// </summary>
+<#
+foreach (var register in eventMetadata)
+{
+#>
+    /// <seealso cref="<#= register.Name #>"/>
+<#
+}
+#>
+<#
+foreach (var register in eventMetadata)
+{
+#>
+    [XmlInclude(typeof(<#= register.Name #>))]
+<#
+}
+#>
+    public partial class <#= eventClassName #> : EventBuilder
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="<#= eventClassName #>"/> class.
+        /// </summary>
+        public <#= eventClassName #>()
+        {
+            Event = new <#= eventMetadata.First().Name #>();
+        }
+    }
+<#
+foreach (var register in eventMetadata)
+{
+    var interfaceType = register.InterfaceType;
+    var payloadSuffix = register.PayloadTypeSuffix;
+    var conversion = !string.IsNullOrEmpty(register.MaskType) ? $"({register.MaskType})" : string.Empty;
+    var summaryDescription = string.IsNullOrEmpty(register.Description)
+        ? $"from register {register.Name}"
+        : $"that {char.ToLower(register.Description[0])}{register.Description.Substring(1).TrimEnd('.')}";
+#>
+
+    /// <summary>
+    /// Represents an operator which filters and selects a sequence of event messages
+    /// <#= summaryDescription #>.
+    /// </summary>
+    [DesignTimeVisible(false)]
+    [Description("Filters and selects a sequence of event messages <#= summaryDescription #>.")]
+    public partial class <#= register.Name #> : Combinator<HarpMessage, <#= interfaceType #>>
+    {
+        /// <summary>
+        /// Filters and selects an observable sequence of event messages
+        /// <#= summaryDescription #>.
+        /// </summary>
+        /// <param name="source">The sequence of Harp event messages.</param>
+        /// <returns>
+        /// A sequence of <see cref="<#= interfaceType #>"/> objects representing the
+        /// register payload.
+        /// </returns>
+        public override IObservable<<#= interfaceType #>> Process(IObservable<HarpMessage> source)
+        {
+            return source.Event(address: <#= register.Address #>).Select(input => <#= conversion #>input.GetPayload<#= payloadSuffix #>());
+        }
+    }
+<#
+}
+#>
+
+    /// <summary>
+    /// Represents an operator which creates standard command messages for the
+    /// Harp device.
+    /// </summary>
+<#
+foreach (var register in commandMetadata)
+{
+#>
+    /// <seealso cref="<#= register.Name #>"/>
+<#
+}
+#>
+<#
+foreach (var register in commandMetadata)
+{
+#>
+    [XmlInclude(typeof(<#= register.Name #>))]
+<#
+}
+#>
+    public partial class <#= commandClassName #> : CommandBuilder
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="<#= commandClassName #>"/> class.
+        /// </summary>
+        public <#= commandClassName #>()
+        {
+            Command = new <#= commandMetadata.First().Name #>();
+        }
+    }
+<#
+foreach (var register in commandMetadata)
+{
+    var interfaceType = register.InterfaceType;
+    var payloadSuffix = register.PayloadTypeSuffix;
+    var conversion = !string.IsNullOrEmpty(register.MaskType) ? $"({Converter.GetInterfaceType(register.PayloadType)})" : string.Empty;
+    var summaryDescription = string.IsNullOrEmpty(register.Description)
+        ? $"to write on register {register.Name}"
+        : $"that {char.ToLower(register.Description[0])}{register.Description.Substring(1).TrimEnd('.')}";
+#>
+
+    /// <summary>
+    /// Represents an operator that creates a sequence of command messages
+    /// <#= summaryDescription #>.
+    /// </summary>
+    [DesignTimeVisible(false)]
+    [Description("Creates a sequence of command messages <#= summaryDescription #>.")]
+    public partial class <#= register.Name #> : Combinator<<#= interfaceType #>, HarpMessage>
+    {
+        public override IObservable<HarpMessage> Process(IObservable<<#= interfaceType #>> source)
+        {
+            return source.Select(input => HarpCommand.Write<#= payloadSuffix #>(address: <#= register.Address #>, <#= conversion #>input));
+        }
+    }
+<#
+}
+#>
+<#
+foreach (var mask in deviceMetadata.Masks)
+{
+#>
+
+    /// <summary>
+    /// <#= mask.Description #>
+    /// </summary>
+    [Flags]
+    public enum <#= mask.Name #> : <#= mask.InterfaceType #>
+    {
+<#
+    var bitIndex = 0;
+    foreach (var bitField in mask.Bits)
+    {
+#>
+        <#= bitField.Key #> = 0x<#= bitField.Value.ToString("X") #><#= ++bitIndex < mask.Bits.Count ? "," : string.Empty #>
+<#
+    }
+#>
+    }
+<#
+}
+#>
+}

--- a/interface/Device.tt
+++ b/interface/Device.tt
@@ -142,7 +142,28 @@ foreach (var registerMetadata in eventMetadata)
     [DesignTimeVisible(false)]
     [Description("Filters and selects a sequence of event messages <#= summaryDescription #>.")]
     public partial class <#= registerMetadata.Key #> : Combinator<HarpMessage, <#= interfaceType #>>
+    {<#
+    if (register.PayloadSpec != null)
     {
+#>
+
+        static <#= interfaceType #> Parse(<#= register.PayloadInterfaceType #> payload)
+        {
+            <#= interfaceType #> result;
+<#
+        foreach (var member in register.PayloadSpec)
+        {
+            var memberConversion = Converter.GetPayloadMemberParser(member.Value, "payload");
+#>
+            result.<#= member.Key #> = <#= memberConversion #>;
+<#
+        }
+#>
+            return result;
+        }
+<#
+    }#>
+
         /// <summary>
         /// Filters and selects an observable sequence of event messages
         /// <#= summaryDescription #>.

--- a/interface/Harp.tt
+++ b/interface/Harp.tt
@@ -10,42 +10,42 @@ public class DeviceInfo
     public string Device;
     public int WhoAmI;
     public HarpVersion FirmwareVersion;
-    public HarpVersion HardwareVersion;
-    public List<RegisterInfo> Registers = new List<RegisterInfo>();
-    public List<BitMaskInfo> Masks = new List<BitMaskInfo>();
+    public HarpVersion HardwareTargets;
+    public Dictionary<string, RegisterInfo> Registers = new Dictionary<string, RegisterInfo>();
+    public Dictionary<string, BitMaskInfo> BitMasks = new Dictionary<string, BitMaskInfo>();
+    public Dictionary<string, GroupMaskInfo> GroupMasks = new Dictionary<string, GroupMaskInfo>();
 }
 
 public enum RegisterType
 {
     Command,
-    Event
+    Event,
+    Both
 }
 
 public class RegisterInfo
 {
-    public string Name;
     public int Address;
+    public string Description = "";
     public PayloadType PayloadType;
     public RegisterType RegisterType;
-    public string Description = "";
-    public string ArrayType;
+    public Dictionary<string, PayloadMemberInfo> PayloadSpec;
     public string MaskType;
 
     public string PayloadTypeSuffix => Converter.GetPayloadTypeSuffix(PayloadType);
     public string PayloadInterfaceType => Converter.GetInterfaceType(PayloadType);
-    public string InterfaceType
-    {
-        get
-        {
-            if (!string.IsNullOrEmpty(MaskType)) return MaskType;
-            else return Converter.GetInterfaceType(PayloadType);
-        }
-    }
+}
+
+public class PayloadMemberInfo
+{
+    public int? Mask;
+    public int? Offset;
+    public string MaskType;
+    public string Description = "";
 }
 
 public class BitMaskInfo
 {
-    public string Name;
     public PayloadType PayloadType;
     public string Description = "";
     public Dictionary<string, int> Bits = new Dictionary<string, int>();
@@ -53,8 +53,24 @@ public class BitMaskInfo
     public string InterfaceType => Converter.GetInterfaceType(PayloadType);
 }
 
+public class GroupMaskInfo
+{
+    public PayloadType PayloadType;
+    public string Description = "";
+    public Dictionary<string, int> Values = new Dictionary<string, int>();
+
+    public string InterfaceType => Converter.GetInterfaceType(PayloadType);
+}
+
 public static class Converter
 {
+    public static string GetInterfaceType(string name, RegisterInfo register)
+    {
+        if (register.PayloadSpec != null) return $"{name}Payload";
+        else if (!string.IsNullOrEmpty(register.MaskType)) return register.MaskType;
+        else return Converter.GetInterfaceType(register.PayloadType);
+    }
+
     public static string GetInterfaceType(PayloadType payloadType)
     {
         switch (payloadType)
@@ -68,7 +84,7 @@ public static class Converter
             case PayloadType.U64: return "ulong";
             case PayloadType.S64: return "long";
             case PayloadType.Float: return "float";
-            default: throw new ArgumentOutOfRangeException(nameof(PayloadType));
+            default: throw new ArgumentOutOfRangeException(nameof(payloadType));
         }
     }
 
@@ -85,7 +101,18 @@ public static class Converter
             case PayloadType.U64: return "UInt64";
             case PayloadType.S64: return "Int64";
             case PayloadType.Float: return "Single";
-            default: throw new ArgumentOutOfRangeException(nameof(PayloadType));
+            default: throw new ArgumentOutOfRangeException(nameof(payloadType));
+        }
+    }
+
+    public static string GetEventConversion(RegisterInfo register, string expression)
+    {
+        var maskType = register.MaskType;
+        if (string.IsNullOrEmpty(maskType)) return expression;
+        switch (maskType)
+        {
+            case "bool": return $"{expression} != 0";
+            default: return $"({maskType}){expression}";
         }
     }
 }

--- a/interface/Harp.tt
+++ b/interface/Harp.tt
@@ -23,6 +23,12 @@ public enum RegisterType
     Both
 }
 
+public enum RegisterVisibility
+{
+    Public,
+    Private
+}
+
 public class RegisterInfo
 {
     public int Address;
@@ -31,6 +37,7 @@ public class RegisterInfo
     public PayloadType PayloadType;
     public int PayloadLength;
     public Dictionary<string, PayloadMemberInfo> PayloadSpec;
+    public RegisterVisibility Visibility;
     public string MaskType;
 
     public string PayloadTypeSuffix => Converter.GetPayloadTypeSuffix(PayloadType, PayloadLength);

--- a/interface/Harp.tt
+++ b/interface/Harp.tt
@@ -27,13 +27,14 @@ public class RegisterInfo
 {
     public int Address;
     public string Description = "";
-    public PayloadType PayloadType;
     public RegisterType RegisterType;
+    public PayloadType PayloadType;
+    public int PayloadLength;
     public Dictionary<string, PayloadMemberInfo> PayloadSpec;
     public string MaskType;
 
-    public string PayloadTypeSuffix => Converter.GetPayloadTypeSuffix(PayloadType);
-    public string PayloadInterfaceType => Converter.GetInterfaceType(PayloadType);
+    public string PayloadTypeSuffix => Converter.GetPayloadTypeSuffix(PayloadType, PayloadLength);
+    public string PayloadInterfaceType => Converter.GetInterfaceType(PayloadType, PayloadLength);
 }
 
 public class PayloadMemberInfo
@@ -88,8 +89,21 @@ public static class Converter
         }
     }
 
-    public static string GetPayloadTypeSuffix(PayloadType payloadType)
+    public static string GetInterfaceType(PayloadType payloadType, int payloadLength)
     {
+        var baseType = GetInterfaceType(payloadType);
+        if (payloadLength > 0) return $"{baseType}[]";
+        else return baseType;
+    }
+
+    public static string GetPayloadTypeSuffix(PayloadType payloadType, int payloadLength)
+    {
+        if (payloadLength > 0)
+        {
+            var baseType = GetInterfaceType(payloadType);
+            return $"Array<{baseType}>";
+        }
+
         switch (payloadType)
         {
             case PayloadType.U8: return "Byte";
@@ -108,12 +122,39 @@ public static class Converter
     public static string GetEventConversion(RegisterInfo register, string expression)
     {
         var maskType = register.MaskType;
+        if (register.PayloadSpec != null) return $"Parse({expression})";
+        return GetConversionToMaskType(maskType, expression);
+    }
+
+    public static string GetConversionToMaskType(string maskType, string expression)
+    {
         if (string.IsNullOrEmpty(maskType)) return expression;
         switch (maskType)
         {
             case "bool": return $"{expression} != 0";
             default: return $"({maskType}){expression}";
         }
+    }
+
+    public static string GetPayloadMemberParser(PayloadMemberInfo member, string expression)
+    {
+        if (member.Offset.HasValue)
+        {
+            expression = $"{expression}[{member.Offset.Value}]";
+        }
+        if (member.Mask.HasValue)
+        {
+            var mask = member.Mask.Value;
+            var lsb = mask & (~mask + 1);
+            var shift = (int)Math.Log(lsb, 2);
+            expression = $"({expression} & 0x{mask.ToString("X")})";
+            if (shift > 0 && member.MaskType != "bool")
+            {
+                expression = $"({expression} >> {shift})";
+            }
+        }
+        expression = GetConversionToMaskType(member.MaskType, expression);
+        return expression;
     }
 }
 #>

--- a/interface/Harp.tt
+++ b/interface/Harp.tt
@@ -47,20 +47,18 @@ public class PayloadMemberInfo
 
 public class BitMaskInfo
 {
-    public PayloadType PayloadType;
     public string Description = "";
     public Dictionary<string, int> Bits = new Dictionary<string, int>();
 
-    public string InterfaceType => Converter.GetInterfaceType(PayloadType);
+    public string InterfaceType => Converter.GetInterfaceType(Bits);
 }
 
 public class GroupMaskInfo
 {
-    public PayloadType PayloadType;
     public string Description = "";
     public Dictionary<string, int> Values = new Dictionary<string, int>();
 
-    public string InterfaceType => Converter.GetInterfaceType(PayloadType);
+    public string InterfaceType => Converter.GetInterfaceType(Values);
 }
 
 public static class Converter
@@ -94,6 +92,14 @@ public static class Converter
         var baseType = GetInterfaceType(payloadType);
         if (payloadLength > 0) return $"{baseType}[]";
         else return baseType;
+    }
+
+    public static string GetInterfaceType(Dictionary<string, int> maskValues)
+    {
+        var max = maskValues.Values.Max();
+        if (max <= byte.MaxValue) return "byte";
+        if (max <= ushort.MaxValue) return "ushort";
+        else return "uint";
     }
 
     public static string GetPayloadTypeSuffix(PayloadType payloadType, int payloadLength)

--- a/interface/Harp.tt
+++ b/interface/Harp.tt
@@ -40,7 +40,6 @@ public class RegisterInfo
     public RegisterVisibility Visibility;
     public string MaskType;
 
-    public string PayloadTypeSuffix => Converter.GetPayloadTypeSuffix(PayloadType, PayloadLength);
     public string PayloadInterfaceType => Converter.GetInterfaceType(PayloadType, PayloadLength);
 }
 
@@ -109,7 +108,7 @@ public static class Converter
         else return "uint";
     }
 
-    public static string GetPayloadTypeSuffix(PayloadType payloadType, int payloadLength)
+    public static string GetPayloadTypeSuffix(PayloadType payloadType, int payloadLength = 0)
     {
         if (payloadLength > 0)
         {
@@ -139,6 +138,12 @@ public static class Converter
         return GetConversionToMaskType(maskType, expression);
     }
 
+    public static string GetCommandConversion(RegisterInfo register, string expression)
+    {
+        if (register.PayloadSpec != null) return $"Format({expression})";
+        return GetConversionToMaskType(register.PayloadInterfaceType, expression);
+    }
+
     public static string GetConversionToMaskType(string maskType, string expression)
     {
         if (string.IsNullOrEmpty(maskType)) return expression;
@@ -147,6 +152,12 @@ public static class Converter
             case "bool": return $"{expression} != 0";
             default: return $"({maskType}){expression}";
         }
+    }
+
+    static int GetMaskShift(int mask)
+    {
+        var lsb = mask & (~mask + 1);
+        return (int)Math.Log(lsb, 2);
     }
 
     public static string GetPayloadMemberParser(PayloadMemberInfo member, string expression)
@@ -158,8 +169,7 @@ public static class Converter
         if (member.Mask.HasValue)
         {
             var mask = member.Mask.Value;
-            var lsb = mask & (~mask + 1);
-            var shift = (int)Math.Log(lsb, 2);
+            var shift = GetMaskShift(mask);
             expression = $"({expression} & 0x{mask.ToString("X")})";
             if (shift > 0 && member.MaskType != "bool")
             {
@@ -168,6 +178,36 @@ public static class Converter
         }
         expression = GetConversionToMaskType(member.MaskType, expression);
         return expression;
+    }
+
+    public static string GetPayloadMemberFormatter(
+        PayloadMemberInfo member,
+        string expression,
+        PayloadType payloadType,
+        bool assigned)
+    {
+        var payloadInterfaceType = GetInterfaceType(payloadType);
+        if (!string.IsNullOrEmpty(member.MaskType))
+        {
+            expression = $"({payloadInterfaceType}){expression}";
+        }
+        if (member.Mask.HasValue)
+        {
+            var mask = member.Mask.Value;
+            var shift = GetMaskShift(mask);
+            if (shift > 0 && member.MaskType != "bool")
+            {
+                expression = $"({expression} << {shift})";
+            }
+
+            expression = $"({payloadInterfaceType})({expression} & 0x{mask.ToString("X")})";
+        }
+        
+        if (member.Mask.HasValue && assigned)
+        {
+            return $" |= {expression}";
+        }
+        else return $" = {expression}";
     }
 }
 #>

--- a/interface/Harp.tt
+++ b/interface/Harp.tt
@@ -1,0 +1,92 @@
+﻿<#@ assembly name="System.Core" #>
+<#@ import namespace="System.Linq" #>
+<#@ import namespace="System.Text" #>
+<#@ import namespace="System.Collections.Generic" #>
+<#@ assembly name="$(PkgBonsai_Harp)\\lib\\net462\\Bonsai.Harp.dll" #>
+<#@ import namespace="Bonsai.Harp" #>
+<#+
+public class DeviceInfo
+{
+    public string Device;
+    public int WhoAmI;
+    public HarpVersion FirmwareVersion;
+    public HarpVersion HardwareVersion;
+    public List<RegisterInfo> Registers = new List<RegisterInfo>();
+    public List<BitMaskInfo> Masks = new List<BitMaskInfo>();
+}
+
+public enum RegisterType
+{
+    Command,
+    Event
+}
+
+public class RegisterInfo
+{
+    public string Name;
+    public int Address;
+    public PayloadType PayloadType;
+    public RegisterType RegisterType;
+    public string Description = "";
+    public string ArrayType;
+    public string MaskType;
+
+    public string PayloadTypeSuffix => Converter.GetPayloadTypeSuffix(PayloadType);
+    public string PayloadInterfaceType => Converter.GetInterfaceType(PayloadType);
+    public string InterfaceType
+    {
+        get
+        {
+            if (!string.IsNullOrEmpty(MaskType)) return MaskType;
+            else return Converter.GetInterfaceType(PayloadType);
+        }
+    }
+}
+
+public class BitMaskInfo
+{
+    public string Name;
+    public PayloadType PayloadType;
+    public string Description = "";
+    public Dictionary<string, int> Bits = new Dictionary<string, int>();
+
+    public string InterfaceType => Converter.GetInterfaceType(PayloadType);
+}
+
+public static class Converter
+{
+    public static string GetInterfaceType(PayloadType payloadType)
+    {
+        switch (payloadType)
+        {
+            case PayloadType.U8: return "byte";
+            case PayloadType.S8: return "sbyte";
+            case PayloadType.U16: return "ushort";
+            case PayloadType.S16: return "short";
+            case PayloadType.U32: return "uint";
+            case PayloadType.S32: return "int";
+            case PayloadType.U64: return "ulong";
+            case PayloadType.S64: return "long";
+            case PayloadType.Float: return "float";
+            default: throw new ArgumentOutOfRangeException(nameof(PayloadType));
+        }
+    }
+
+    public static string GetPayloadTypeSuffix(PayloadType payloadType)
+    {
+        switch (payloadType)
+        {
+            case PayloadType.U8: return "Byte";
+            case PayloadType.S8: return "SByte";
+            case PayloadType.U16: return "UInt16";
+            case PayloadType.S16: return "Int16";
+            case PayloadType.U32: return "UInt32";
+            case PayloadType.S32: return "Int32";
+            case PayloadType.U64: return "UInt64";
+            case PayloadType.S64: return "Int64";
+            case PayloadType.Float: return "Single";
+            default: throw new ArgumentOutOfRangeException(nameof(PayloadType));
+        }
+    }
+}
+#>

--- a/schema/device.json
+++ b/schema/device.json
@@ -58,7 +58,6 @@
                     "description": "Specifies a summary description of the bit mask function.",
                     "type": "string"
                 },
-                "payloadType": { "$ref": "#/definitions/payloadType" },
                 "bits": {
                     "type": "object",
                     "additionalProperties": { "type": "integer" }

--- a/schema/device.json
+++ b/schema/device.json
@@ -80,6 +80,7 @@
                 "address": {
                     "description": "Specifies the unique 8-bit address of the register.",
                     "type": "integer",
+                    "minimum": 32,
                     "maximum": 255
                 },
                 "registerType": {

--- a/schema/device.json
+++ b/schema/device.json
@@ -28,15 +28,15 @@
             "type": "array",
             "items": { "$ref": "#/definitions/register" }
         },
-        "masks": {
+        "bitMasks": {
+            "type": "object",
             "description": "Specifies the collection of masks available to be used with the different registers.",
-            "type": "array",
-            "items": { "$ref": "#/definitions/bitMask" }
+            "additionalProperties": { "$ref": "#/definitions/bitMask" }
         },
         "ios": {
+            "type": "object",
             "description": "Specifies the IO pin configuration used to automatically generate the firmware.",
-            "type": "array",
-            "items": { "$ref": "#/definitions/pin" }
+            "additionalProperties": { "$ref": "#/definitions/pin" }
         }
     },
     "required": ["device", "whoAmI", "firmwareVersion", "hardwareTargets", "registers"],
@@ -50,10 +50,6 @@
             "description": "Specifies a bit mask used for reading or writing specific registers.",
             "type": "object",
             "properties": {
-                "name": {
-                    "description": "Specifies the unique name of the bit mask.",
-                    "type": "string"
-                },
                 "description": {
                     "description": "Specifies a summary description of the bit mask function.",
                     "type": "string"
@@ -63,7 +59,7 @@
                     "additionalProperties": { "type": "integer" }
                 }
             },
-            "required": ["name", "payloadType"]
+            "required": ["bits"]
         },
         "register": {
             "type": "object",
@@ -124,10 +120,6 @@
         "pin": {
             "type": "object",
             "properties": {
-                "name": {
-                    "description":"Specifies the unique name of the IO pin.",
-                    "type": "string"
-                },
                 "description": {
                     "description": "Specifies a summary description of the IO function.",
                     "type": "string"

--- a/schema/device.json
+++ b/schema/device.json
@@ -129,15 +129,16 @@
                     "type": "integer"
                 },
                 "payloadSpec": {
-                    "oneOf": [
-                        {
-                            "$ref": "#/definitions/payloadMember"
-                        },
-                        {
-                            "type": "object",
-                            "additionalProperties": { "$ref": "#/definitions/payloadMember" }
-                        }
-                    ]
+                    "type": "object",
+                    "additionalProperties": { "$ref": "#/definitions/payloadMember" }
+                },
+                "maskType": {
+                    "description": "Specifies the name of the bit mask or group mask used to represent the payload data.",
+                    "type": "string"
+                },
+                "converter": {
+                    "description": "Flags the existence of an optional converter method used to parse or format the payload value in the high-level interface.",
+                    "type": "boolean"
                 },
                 "visibility": {
                     "description": "Specifies whether the register function is exposed in the high-level interface.",

--- a/schema/device.json
+++ b/schema/device.json
@@ -83,6 +83,7 @@
         },
         "payloadMember": {
             "type": "object",
+            "additionalProperties": false,
             "properties": {
                 "mask": {
                     "description": "Specifies the mask used to read and write this payload member.",

--- a/schema/device.json
+++ b/schema/device.json
@@ -133,7 +133,7 @@
                     "description": "Specifies a summary description of the IO function.",
                     "type": "string"
                 },
-                "port": {
+                "portName": {
                     "description": "Specifies the microcontroller port.",
                     "type": "string"
                 },
@@ -167,13 +167,13 @@
                 },
                 "interruptNumber":{
                     "description": "Specifies the interrupt number associated with the specific pin.",
-                    "type": "string",
-                    "enum": ["INT0", "INT1"]
+                    "type": "integer",
+                    "enum": [0, 1]
                 },
                 "out":{
                     "description": "ONLY OUTPUTS. Specifies output mode of the pin.",
                     "type": "string",
-                    "enum": ["digital", "wire_or", "wire_and", "wired_or_pull", "wired_and_pull"]
+                    "enum": ["digital", "wireOr", "wireAnd", "wiredOrPull", "wiredAndPull"]
                 },
                 "outDefault":{
                     "description": "Specifies the initial state of the output line at boot time.",
@@ -184,7 +184,7 @@
                     "type": "boolean"
                 }
             },
-            "required": ["name", "port", "pin", "direction"]
+            "required": ["portName", "pinNumber", "direction"]
         }
     }
 }

--- a/schema/device.json
+++ b/schema/device.json
@@ -24,9 +24,9 @@
             "type": "string"
         },
         "registers": {
+            "type": "object",
             "description": "Specifies the collection of registers implementing the device function.",
-            "type": "array",
-            "items": { "$ref": "#/definitions/register" }
+            "additionalProperties": { "$ref": "#/definitions/register" }
         },
         "bitMasks": {
             "type": "object",
@@ -105,10 +105,6 @@
         "register": {
             "type": "object",
             "properties": {
-                "name": {
-                    "description":"Specifies the unique name of the register.",
-                    "type": "string"
-                },
                 "description": {
                     "description": "Specifies a summary description of the register function.",
                     "type": "string"
@@ -150,7 +146,7 @@
                     "type": "string"
                 }
             },
-            "required": ["name", "address", "registerType", "payloadType"]
+            "required": ["address", "registerType", "payloadType"]
         },
         "pin": {
             "type": "object",

--- a/schema/device.json
+++ b/schema/device.json
@@ -33,6 +33,11 @@
             "description": "Specifies the collection of masks available to be used with the different registers.",
             "additionalProperties": { "$ref": "#/definitions/bitMask" }
         },
+        "groupMasks": {
+            "type": "object",
+            "description": "Specifies the collection of group masks available to be used with the different registers.",
+            "additionalProperties": { "$ref": "#/definitions/groupMask" }
+        },
         "ios": {
             "type": "object",
             "description": "Specifies the IO pin configuration used to automatically generate the firmware.",
@@ -60,6 +65,21 @@
                 }
             },
             "required": ["bits"]
+        },
+        "groupMask": {
+            "description": "Specifies a group mask used for reading or writing specific registers.",
+            "type": "object",
+            "properties": {
+                "description": {
+                    "description": "Specifies a summary description of the group mask function.",
+                    "type": "string"
+                },
+                "values": {
+                    "type": "object",
+                    "additionalProperties": { "type": "integer" }
+                }
+            },
+            "required": ["values"]
         },
         "register": {
             "type": "object",

--- a/schema/device.json
+++ b/schema/device.json
@@ -59,12 +59,13 @@
                     "description": "Specifies a summary description of the bit mask function.",
                     "type": "string"
                 },
+                "payloadType": { "$ref": "#/definitions/payloadType" },
                 "bits": {
                     "type": "object",
                     "additionalProperties": { "type": "integer" }
                 }
             },
-            "required": ["bits"]
+            "required": ["payloadType", "bits"]
         },
         "groupMask": {
             "description": "Specifies a group mask used for reading or writing specific registers.",
@@ -74,12 +75,13 @@
                     "description": "Specifies a summary description of the group mask function.",
                     "type": "string"
                 },
+                "payloadType": { "$ref": "#/definitions/payloadType" },
                 "values": {
                     "type": "object",
                     "additionalProperties": { "type": "integer" }
                 }
             },
-            "required": ["values"]
+            "required": ["payloadType", "values"]
         },
         "payloadMember": {
             "type": "object",

--- a/schema/device.json
+++ b/schema/device.json
@@ -81,6 +81,27 @@
             },
             "required": ["values"]
         },
+        "payloadMember": {
+            "type": "object",
+            "properties": {
+                "mask": {
+                    "description": "Specifies the mask used to read and write this payload member.",
+                    "type": "integer"
+                },
+                "offset": {
+                    "description": "Specifies the payload array offset where this payload member is stored.",
+                    "type": "integer"
+                },
+                "maskType": {
+                    "description": "Specifies the name of the bit mask or group mask used to represent the payload data.",
+                    "type": "string"
+                },
+                "converter": {
+                    "description": "Flags the existence of an optional converter method used to parse or format the payload value in the high-level interface.",
+                    "type": "boolean"
+                }
+            }
+        },
         "register": {
             "type": "object",
             "properties": {
@@ -104,26 +125,20 @@
                     "enum": ["Command", "Event", "Both"]
                 },
                 "payloadType": { "$ref": "#/definitions/payloadType" },
-                "arrayType": {
-                    "description": "Specifies the optional array format for the register payload.",
+                "payloadLength": {
+                    "description": "Specifies the length of the register payload.",
+                    "type": "integer"
+                },
+                "payloadSpec": {
                     "oneOf": [
                         {
-                            "type": "array",
-                            "items": {
-                                "type": "string"
-                            }
+                            "$ref": "#/definitions/payloadMember"
                         },
                         {
-                            "type": "integer"
+                            "type": "object",
+                            "additionalProperties": { "$ref": "#/definitions/payloadMember" }
                         }
                     ]
-                },
-                "maskType": {
-                    "$ref": "#/definitions/bitMask/properties/name"
-                },
-                "converter": {
-                    "description": "Flags the existence of an optional converter method used to parse or format the mask value in the high-level interface.",
-                    "type": "boolean"
                 },
                 "visibility": {
                     "description": "Specifies whether the register function is exposed in the high-level interface.",

--- a/schema/device.json
+++ b/schema/device.json
@@ -85,8 +85,11 @@
         },
         "payloadMember": {
             "type": "object",
-            "additionalProperties": false,
             "properties": {
+                "description": {
+                    "description": "Specifies a summary description of the payload member.",
+                    "type": "string"
+                },
                 "mask": {
                     "description": "Specifies the mask used to read and write this payload member.",
                     "type": "integer"

--- a/schema/example.yml
+++ b/schema/example.yml
@@ -2,75 +2,74 @@
 device: ExampleDevice
 whoAmI: 0000
 firmwareVersion: "0.1"
-hardwareVersion: "0.1"
+hardwareTargets: "0.1"
 architecture: "atmega"
 registers:
-  - name: Cam0Event
+  Cam0Event:
     address: 32
     payloadType: U8
     registerType: Event
-  - name: Cam0TriggerFrequency
+  Cam0TriggerFrequency:
     address: 33
     registerType: Command
     payloadType: U16
     maskType: DO
     description: Sets the trigger frequency for camera 0 between 1 and 1000.
-  - name: Cam0TriggerDuration
+  Cam0TriggerDuration:
     address: 34
     registerType: Command
     payloadType: U16
     description: Sets the duration of the trigger pulse (minimum is 100) for camera 0.
-  - name: StartAndStop
+  StartAndStop:
     address: 35
     registerType: Command
     payloadType: U8
     description: Starts or stops the camera immediately.
-  - name: InState
+  InState:
     address: 36
     registerType: Event
     payloadType: U8
     description: Contains the state of the input ports.
-  - name: Valve0Pulse
+  Valve0Pulse:
     address: 37
     registerType: Command
     payloadType: U8
     description: Configures the valve 0 open time in milliseconds.
-  - name: OutSet
+  OutSet:
     address: 38
     registerType: Command
     payloadType: U8
     description: Bitmask to set the available outputs.
-  - name: OutClear
+  OutClear:
     address: 39
     registerType: Command
     payloadType: U8
     description: Bitmask to clear the available outputs.
-  - name: OutToggle
+  OutToggle:
     address: 40
     registerType: Command
     payloadType: U8
     description: Bitmask to toggle the available outputs.
-  - name: OutWrite
+  OutWrite:
     address: 41
     registerType: Command
     payloadType: U8
     maskType: DO
     description: Bitmask to write the available outputs.
-masks:
-  - name: DO
-    payloadType: U8
+bitMasks:
+  DO:
     description: Bitmask representing the state of the digital outputs.
     bits:
       DO0: 0x01
       DO1: 0x02
 ios:
-  - name: DO3
-    port: PORTC
-    pin: 0
+  DO3:
+    portName: PORTC
+    pinNumber: 0
     direction: output
     description: DO0
-  - name: DO2
-    port: PORTB
-    pin: 2
+  DO2:
+    portName: PORTB
+    pinNumber: 2
     direction: output
     description: DO0

--- a/schema/example.yml
+++ b/schema/example.yml
@@ -59,6 +59,7 @@ registers:
 bitMasks:
   DO:
     description: Bitmask representing the state of the digital outputs.
+    payloadType: U8
     bits:
       DO0: 0x01
       DO1: 0x02


### PR DESCRIPTION
This PR implements a prototype for automatic interface generation using T4 text templates. The T4 template engine has built-in support in Visual Studio and can be used to automatically generate and update code side-by-side with the build process.

The current version of the generator supports most of the functionality in the latest version of the schema, including register visibility, but a test suite would still be an important addition to have to allow future evolution.