### PR TITLE
Fix bool payload formatter

### DIFF
--- a/interface/Harp.tt
+++ b/interface/Harp.tt
@@ -209,21 +209,27 @@ public static class TemplateHelper
         {
             expression = $"{member.Converter}({expression})";
         }
+        var isBoolean = member.MaskType == "bool";
         var payloadInterfaceType = GetInterfaceType(payloadType);
         if (!string.IsNullOrEmpty(member.MaskType))
         {
-            expression = $"({payloadInterfaceType}){expression}";
+            if (isBoolean) expression = $"({expression} ? 1 : 0)";
+            else expression = $"({payloadInterfaceType}){expression}";
         }
         if (member.Mask.HasValue)
         {
             var mask = member.Mask.Value;
             var shift = GetMaskShift(mask);
-            if (shift > 0 && member.MaskType != "bool")
+            if (shift > 0)
             {
                 expression = $"({expression} << {shift})";
             }
 
             expression = $"({payloadInterfaceType})({expression} & 0x{mask.ToString("X")})";
+        }
+        else if (isBoolean)
+        {
+            expression = $"({payloadInterfaceType}){expression}";
         }
         
         if (member.Mask.HasValue && assigned)

--- a/schema/example.yml
+++ b/schema/example.yml
@@ -56,6 +56,18 @@ registers:
     payloadType: U8
     maskType: DO
     description: Bitmask to write the available outputs.
+  AnalogIn:
+    address: 42
+    registerType: Event
+    payloadType: U16
+    payloadLength: 2
+    payloadSpec:
+      ADC:
+        description: The value of the board ADC.
+        offset: 0
+      Encoder:
+        description: The value of the quadrature counter in Port 2.
+        offset: 1
 bitMasks:
   DO:
     description: Bitmask representing the state of the digital outputs.


### PR DESCRIPTION
This PR fixes the formatter for payload type `bool` for completeness. Also updates the example metadata file to include examples of a payload spec.

Fixes #8 