### PR TITLE
Export static format and parse helper methods

### DIFF
--- a/interface/Device.tt
+++ b/interface/Device.tt
@@ -83,7 +83,7 @@ namespace <#= namespaceName #>
         /// <returns>The observable sequence of Harp messages produced by the device.</returns>
         public IObservable<HarpMessage> Generate()
         {
-            return Generate(Observable.Empty<HarpMessage>());
+            return device.Generate();
         }
 
         /// <summary>

--- a/interface/Device.tt
+++ b/interface/Device.tt
@@ -39,13 +39,14 @@ var deviceClassName = deviceName + "Device";
 var eventClassName = deviceName + "Event";
 var commandClassName = deviceName + "Command";
 #>
+using Bonsai;
+using Bonsai.Harp;
 <#
 foreach (var ns in Host.StandardImports)
 {
-    Write("using " + ns + ";");
+    WriteLine("using " + ns + ";");
 }
 #>
-
 using System.ComponentModel;
 using System.Reactive.Linq;
 using System.Xml.Serialization;

--- a/interface/Device.tt
+++ b/interface/Device.tt
@@ -133,7 +133,7 @@ foreach (var registerMetadata in eventMetadata)
 {
     var register = registerMetadata.Value;
     var payloadSuffix = TemplateHelper.GetPayloadTypeSuffix(register.PayloadType, register.PayloadLength);
-    var payloadSelector = $"input.GetPayload{payloadSuffix}()";
+    var payloadSelector = $"message.GetPayload{payloadSuffix}()";
     var interfaceType = TemplateHelper.GetInterfaceType(registerMetadata.Key, register);
     var conversion = TemplateHelper.GetEventConversion(register, payloadSelector);
     var summaryDescription = string.IsNullOrEmpty(register.Description)
@@ -153,7 +153,7 @@ foreach (var registerMetadata in eventMetadata)
     {
 #>
 
-        static <#= interfaceType #> Parse(<#= register.PayloadInterfaceType #> payload)
+        static <#= interfaceType #> ParsePayload(<#= register.PayloadInterfaceType #> payload)
         {
             <#= interfaceType #> result;
 <#
@@ -172,6 +172,20 @@ foreach (var registerMetadata in eventMetadata)
         }
 <#
     }#>
+        
+        /// <summary>
+        /// Returns the payload data for the <see cref="<#= registerMetadata.Key #>"/> event message.
+        /// </summary>
+        /// <param name="message">
+        /// A <see cref="HarpMessage"/> encoding the event payload.
+        /// </param>
+        /// <returns>
+        /// A value representing the message payload <#= summaryDescription #>.
+        /// </returns>
+        public static <#= interfaceType #> Parse(HarpMessage message)
+        {
+            return <#= conversion #>;
+        }
 
         /// <summary>
         /// Filters and selects an observable sequence of event messages
@@ -184,7 +198,7 @@ foreach (var registerMetadata in eventMetadata)
         /// </returns>
         public override IObservable<<#= interfaceType #>> Process(IObservable<HarpMessage> source)
         {
-            return source.Event(address: <#= register.Address #>).Select(input => <#= conversion #>);
+            return source.Event(address: <#= register.Address #>).Select(Parse);
         }
     }
 <#
@@ -227,7 +241,7 @@ foreach (var registerMetadata in commandMetadata)
     var register = registerMetadata.Value;
     var payloadSuffix = TemplateHelper.GetPayloadTypeSuffix(register.PayloadType);
     var interfaceType = TemplateHelper.GetInterfaceType(registerMetadata.Key, register);
-    var conversion = TemplateHelper.GetCommandConversion(register, "input");
+    var conversion = TemplateHelper.GetCommandConversion(register, "value");
     var summaryDescription = string.IsNullOrEmpty(register.Description)
         ? $"to write on register {registerMetadata.Key}"
         : $"that {char.ToLower(register.Description[0])}{register.Description.Substring(1).TrimEnd('.')}";
@@ -245,7 +259,7 @@ foreach (var registerMetadata in commandMetadata)
     {
 #>
 
-        static <#= register.PayloadInterfaceType #> Format(<#= interfaceType #> value)
+        static <#= register.PayloadInterfaceType #> FormatPayload(<#= interfaceType #> value)
         {
             <#= register.PayloadInterfaceType #> result;
 <#
@@ -279,6 +293,21 @@ foreach (var registerMetadata in commandMetadata)
     }#>
 
         /// <summary>
+        /// Creates a command message for the <see cref="<#= registerMetadata.Key #>"/> register.
+        /// </summary>
+        /// <param name="value">
+        /// A value representing the command message payload
+        /// <#= summaryDescription #>.
+        /// </param>
+        /// <returns>
+        /// A <see cref="HarpMessage"/> object representing the command message.
+        /// </returns>
+        public static HarpMessage Format(<#= interfaceType #> value)
+        {
+            return HarpCommand.Write<#= payloadSuffix #>(address: <#= register.Address #>, <#= conversion #>);
+        }
+
+        /// <summary>
         /// Creates an observable sequence of command messages
         /// <#= summaryDescription #>.
         /// </summary>
@@ -292,7 +321,7 @@ foreach (var registerMetadata in commandMetadata)
         /// </returns>
         public override IObservable<HarpMessage> Process(IObservable<<#= interfaceType #>> source)
         {
-            return source.Select(input => HarpCommand.Write<#= payloadSuffix #>(address: <#= register.Address #>, <#= conversion #>));
+            return source.Select(Format);
         }
     }
 <#

--- a/interface/Device.tt
+++ b/interface/Device.tt
@@ -100,7 +100,7 @@ namespace <#= namespaceName #>
 
     /// <summary>
     /// Represents an operator which filters and selects specific event messages
-    /// reported by the Harp device.
+    /// reported by the <#= deviceName #> device.
     /// </summary>
 <#
 foreach (var register in eventMetadata)
@@ -118,6 +118,7 @@ foreach (var register in eventMetadata)
 <#
 }
 #>
+    [Description("Filters and selects specific event messages reported by the <#= deviceName #> device.")]
     public partial class <#= eventClassName #> : EventBuilder
     {
         /// <summary>
@@ -207,7 +208,7 @@ foreach (var registerMetadata in eventMetadata)
 
     /// <summary>
     /// Represents an operator which creates standard command messages for the
-    /// Harp device.
+    /// <#= deviceName #> device.
     /// </summary>
 <#
 foreach (var register in commandMetadata)
@@ -225,6 +226,7 @@ foreach (var register in commandMetadata)
 <#
 }
 #>
+    [Description("Creates standard command messages for the <#= deviceName #> device.")]
     public partial class <#= commandClassName #> : CommandBuilder
     {
         /// <summary>

--- a/interface/Device.tt
+++ b/interface/Device.tt
@@ -1,4 +1,4 @@
-﻿<#@ template debug="false" hostspecific="true" language="C#" #>
+<#@ template debug="false" hostspecific="true" language="C#" #>
 <#@ assembly name="System.Core" #>
 <#@ import namespace="System.IO" #>
 <#@ import namespace="System.Linq" #>
@@ -278,6 +278,18 @@ foreach (var registerMetadata in commandMetadata)
 <#
     }#>
 
+        /// <summary>
+        /// Creates an observable sequence of command messages
+        /// <#= summaryDescription #>.
+        /// </summary>
+        /// <param name="source">
+        /// A sequence of <see cref="<#= interfaceType #>"/> objects representing the
+        /// register payload.
+        /// </param>
+        /// <returns>
+        /// A sequence of <see cref="HarpMessage"/> objects representing each
+        /// command message.
+        /// </returns>
         public override IObservable<HarpMessage> Process(IObservable<<#= interfaceType #>> source)
         {
             return source.Select(input => HarpCommand.Write<#= payloadSuffix #>(address: <#= register.Address #>, <#= conversion #>));

--- a/interface/Harp.tt
+++ b/interface/Harp.tt
@@ -146,7 +146,7 @@ public static class TemplateHelper
         var converter = register.Converter;
         if (!string.IsNullOrEmpty(converter)) return $"{converter}({expression})";
         if (register.PayloadSpec != null) return $"FormatPayload({expression})";
-        return GetConversionToMaskType(register.PayloadInterfaceType, expression);
+        return GetConversionFromInterfaceType(register.MaskType, register.PayloadInterfaceType, expression);
     }
 
     public static string GetConversionToMaskType(string maskType, string expression)
@@ -157,6 +157,24 @@ public static class TemplateHelper
             case "bool": return $"{expression} != 0";
             default: return $"({maskType}){expression}";
         }
+    }
+
+    public static string GetConversionFromInterfaceType(
+        string maskType,
+        string payloadInterfaceType,
+        string expression)
+    {
+        var isBoolean = maskType == "bool";
+        if (!string.IsNullOrEmpty(maskType))
+        {
+            if (isBoolean) expression = $"({expression} ? 1 : 0)";
+            else expression = $"({payloadInterfaceType}){expression}";
+        }
+        if (isBoolean)
+        {
+            expression = $"({payloadInterfaceType}){expression}";
+        }
+        return expression;
     }
 
     static int GetMaskShift(int mask)

--- a/interface/Harp.tt
+++ b/interface/Harp.tt
@@ -137,7 +137,7 @@ public static class TemplateHelper
     {
         var converter = register.Converter;
         if (!string.IsNullOrEmpty(converter)) return $"{converter}({expression})";
-        if (register.PayloadSpec != null) return $"Parse({expression})";
+        if (register.PayloadSpec != null) return $"ParsePayload({expression})";
         return GetConversionToMaskType(register.MaskType, expression);
     }
 
@@ -145,7 +145,7 @@ public static class TemplateHelper
     {
         var converter = register.Converter;
         if (!string.IsNullOrEmpty(converter)) return $"{converter}({expression})";
-        if (register.PayloadSpec != null) return $"Format({expression})";
+        if (register.PayloadSpec != null) return $"FormatPayload({expression})";
         return GetConversionToMaskType(register.PayloadInterfaceType, expression);
     }
 

--- a/interface/Harp.tt
+++ b/interface/Harp.tt
@@ -1,4 +1,4 @@
-﻿<#@ assembly name="System.Core" #>
+<#@ assembly name="System.Core" #>
 <#@ import namespace="System.Linq" #>
 <#@ import namespace="System.Text" #>
 <#@ import namespace="System.Collections.Generic" #>
@@ -75,7 +75,7 @@ public static class TemplateHelper
     {
         if (register.PayloadSpec != null) return $"{name}Payload";
         else if (!string.IsNullOrEmpty(register.MaskType)) return register.MaskType;
-        else return GetInterfaceType(register.PayloadType);
+        else return GetInterfaceType(register.PayloadType, register.PayloadLength);
     }
 
     public static string GetInterfaceType(PayloadType payloadType)

--- a/interface/Harp.tt
+++ b/interface/Harp.tt
@@ -16,11 +16,11 @@ public class DeviceInfo
     public Dictionary<string, GroupMaskInfo> GroupMasks = new Dictionary<string, GroupMaskInfo>();
 }
 
+[Flags]
 public enum RegisterType
 {
-    Command,
-    Event,
-    Both
+    Command = 0x1,
+    Event = 0x2
 }
 
 public enum RegisterVisibility

--- a/schema/device.json
+++ b/schema/device.json
@@ -122,7 +122,7 @@
                 "registerType": {
                     "description": "Specifies the expected use of the register.",
                     "type": "string",
-                    "enum": ["Command", "Event", "Both"]
+                    "enum": ["Command", "Event"]
                 },
                 "payloadType": { "$ref": "#/definitions/payloadType" },
                 "payloadLength": {


### PR DESCRIPTION
This PR extends the generator to export static `Format` and `Parse` helper methods implementing all payload manipulations. This makes it easier to provide an API to the device which is independent of observable sequences.

The PR also fixes outstanding issues with the auto-generated device class and raw array payload conversion, and improves the handling of arbitrary project namespaces.