### PR TITLE
Refactor to create command payload from properties

### DIFF
--- a/interface/Device.tt
+++ b/interface/Device.tt
@@ -20,8 +20,8 @@ var templateFileName = Path.GetFileNameWithoutExtension(Host.TemplateFile);
 var metadataFileName = Path.Combine(metadataPath, templateFileName) + ".yml";
 
 DeviceInfo deviceMetadata;
-IEnumerable<KeyValuePair<string, RegisterInfo>> eventMetadata;
-IEnumerable<KeyValuePair<string, RegisterInfo>> commandMetadata;
+List<KeyValuePair<string, RegisterInfo>> eventMetadata;
+List<KeyValuePair<string, RegisterInfo>> commandMetadata;
 using (var reader = new StreamReader(metadataFileName))
 {
     var deserializer = new DeserializerBuilder()
@@ -30,8 +30,8 @@ using (var reader = new StreamReader(metadataFileName))
 
     deviceMetadata = deserializer.Deserialize<DeviceInfo>(reader);
     var publicRegisters = deviceMetadata.Registers.Where(register => register.Value.Visibility == RegisterVisibility.Public);
-    eventMetadata = publicRegisters.Where(register => register.Value.RegisterType == RegisterType.Event);
-    commandMetadata = publicRegisters.Where(register => register.Value.RegisterType == RegisterType.Command);
+    eventMetadata = publicRegisters.Where(register => register.Value.RegisterType == RegisterType.Event).ToList();
+    commandMetadata = publicRegisters.Where(register => register.Value.RegisterType == RegisterType.Command).ToList();
 }
 
 var deviceName = deviceMetadata.Device;
@@ -97,6 +97,10 @@ namespace <#= namespaceName #>
             return device.Generate(source);
         }
     }
+<#
+if (eventMetadata.Count > 0)
+{
+#>
 
     /// <summary>
     /// Represents an operator which filters and selects specific event messages
@@ -204,6 +208,13 @@ foreach (var registerMetadata in eventMetadata)
     }
 <#
 }
+#>
+<#
+} // eventMetadata.Count > 0
+#>
+<#
+if (commandMetadata.Count > 0)
+{
 #>
 
     /// <summary>
@@ -405,6 +416,9 @@ foreach (var registerMetadata in commandMetadata)
     }
 <#
 }
+#>
+<#
+} // commandMetadata.Count > 0
 #>
 <#
 foreach (var registerMetadata in deviceMetadata.Registers)

--- a/interface/Device.tt
+++ b/interface/Device.tt
@@ -1,4 +1,4 @@
-<#@ template debug="false" hostspecific="true" language="C#" #>
+﻿<#@ template debug="false" hostspecific="true" language="C#" #>
 <#@ assembly name="System.Core" #>
 <#@ import namespace="System.IO" #>
 <#@ import namespace="System.Linq" #>
@@ -254,9 +254,41 @@ foreach (var registerMetadata in commandMetadata)
     /// <#= summaryDescription #>.
     /// </summary>
     [DesignTimeVisible(false)]
+    [WorkflowElementCategory(ElementCategory.Transform)]
     [Description("Creates a sequence of command messages <#= summaryDescription #>.")]
-    public partial class <#= registerMetadata.Key #> : Combinator<<#= interfaceType #>, HarpMessage>
+    public partial class <#= registerMetadata.Key #> : Combinator<HarpMessage>
     {<#
+    if (register.PayloadSpec != null)
+    {
+        foreach (var member in register.PayloadSpec)
+        {
+            var memberType = TemplateHelper.GetPayloadMemberType(member.Value, register.PayloadType);
+            var memberDescription = string.IsNullOrEmpty(member.Value.Description)
+                ? $"to write on payload member {member.Key}"
+                : $"that {char.ToLower(member.Value.Description[0])}{member.Value.Description.Substring(1).TrimEnd('.')}";
+#>
+
+        /// <summary>
+        /// Gets or sets a value <#= memberDescription #>.
+        /// </summary>
+        [Description("<#= member.Value.Description #>")]
+        public <#= memberType #> <#= member.Key #> { get; set; }
+<#
+        }
+    }
+    else
+    {
+#>
+
+        /// <summary>
+        /// Gets or sets the value <#= summaryDescription #>.
+        /// </summary>
+        [Description("The value <#= summaryDescription #>.")]
+        public <#= interfaceType #> Value { get; set; }
+<#
+    }
+#>
+<#
     if (register.PayloadSpec != null && string.IsNullOrEmpty(register.Converter))
     {
 #>
@@ -321,9 +353,34 @@ foreach (var registerMetadata in commandMetadata)
         /// A sequence of <see cref="HarpMessage"/> objects representing each
         /// command message.
         /// </returns>
-        public override IObservable<HarpMessage> Process(IObservable<<#= interfaceType #>> source)
+        public override IObservable<HarpMessage> Process<TSource>(IObservable<TSource> source)
         {
-            return source.Select(Format);
+<#
+    if (register.PayloadSpec != null)
+    {
+#>
+            return source.Select(_ =>
+            {
+                <#= interfaceType #> value;
+<#
+        foreach (var member in register.PayloadSpec)
+        {
+#>
+                value.<#= member.Key #> = <#= member.Key #>;
+<#
+        }
+#>
+                return Format(value);
+            });
+<#
+    }
+    else
+    {
+#>
+            return source.Select(_ => Format(Value));
+<#
+    }
+#>
         }
     }
 <#
@@ -343,9 +400,7 @@ foreach (var registerMetadata in deviceMetadata.Registers)
     {<#
     foreach (var member in register.PayloadSpec)
     {
-        var memberType = string.IsNullOrEmpty(member.Value.MaskType)
-            ? TemplateHelper.GetInterfaceType(register.PayloadType)
-            : member.Value.MaskType;
+        var memberType = TemplateHelper.GetPayloadMemberType(member.Value, register.PayloadType);
 #>
 
         /// <summary>

--- a/interface/Device.tt
+++ b/interface/Device.tt
@@ -244,6 +244,7 @@ foreach (var registerMetadata in commandMetadata)
     var payloadSuffix = TemplateHelper.GetPayloadTypeSuffix(register.PayloadType);
     var interfaceType = TemplateHelper.GetInterfaceType(registerMetadata.Key, register);
     var conversion = TemplateHelper.GetCommandConversion(register, "value");
+    var defaultValue = TemplateHelper.GetDefaultValueAssignment(register.DefaultValue, register.MinValue);
     var summaryDescription = string.IsNullOrEmpty(register.Description)
         ? $"to write on register {registerMetadata.Key}"
         : $"that {char.ToLower(register.Description[0])}{register.Description.Substring(1).TrimEnd('.')}";
@@ -263,6 +264,7 @@ foreach (var registerMetadata in commandMetadata)
         foreach (var member in register.PayloadSpec)
         {
             var memberType = TemplateHelper.GetPayloadMemberType(member.Value, register.PayloadType);
+            defaultValue = TemplateHelper.GetDefaultValueAssignment(member.Value.DefaultValue, member.Value.MinValue);
             var memberDescription = string.IsNullOrEmpty(member.Value.Description)
                 ? $"to write on payload member {member.Key}"
                 : $"that {char.ToLower(member.Value.Description[0])}{member.Value.Description.Substring(1).TrimEnd('.')}";
@@ -271,8 +273,17 @@ foreach (var registerMetadata in commandMetadata)
         /// <summary>
         /// Gets or sets a value <#= memberDescription #>.
         /// </summary>
+<#
+            if (member.Value.MinValue.HasValue || member.Value.MaxValue.HasValue)
+            {
+#>
+        <#= TemplateHelper.GetRangeAttributeDeclaration(member.Value.MinValue, member.Value.MaxValue) #>
+        [Editor(DesignTypes.NumericUpDownEditor, DesignTypes.UITypeEditor)]
+<#
+            }
+#>
         [Description("<#= member.Value.Description #>")]
-        public <#= memberType #> <#= member.Key #> { get; set; }
+        public <#= memberType #> <#= member.Key #> { get; set; }<#= defaultValue #>
 <#
         }
     }
@@ -283,8 +294,17 @@ foreach (var registerMetadata in commandMetadata)
         /// <summary>
         /// Gets or sets the value <#= summaryDescription #>.
         /// </summary>
+<#
+        if (register.MinValue.HasValue || register.MaxValue.HasValue)
+        {
+#>
+        <#= TemplateHelper.GetRangeAttributeDeclaration(register.MinValue, register.MaxValue) #>
+        [Editor(DesignTypes.NumericUpDownEditor, DesignTypes.UITypeEditor)]
+<#
+        }
+#>
         [Description("The value <#= summaryDescription #>.")]
-        public <#= interfaceType #> Value { get; set; }
+        public <#= interfaceType #> Value { get; set; }<#= defaultValue #>
 <#
     }
 #>

--- a/interface/Harp.tt
+++ b/interface/Harp.tt
@@ -40,6 +40,9 @@ public class RegisterInfo
     public RegisterVisibility Visibility;
     public string MaskType;
     public string Converter;
+    public float? MinValue;
+    public float? MaxValue;
+    public float? DefaultValue;
 
     public string PayloadInterfaceType => TemplateHelper.GetInterfaceType(PayloadType, PayloadLength);
 }
@@ -51,6 +54,9 @@ public class PayloadMemberInfo
     public string MaskType;
     public string Converter;
     public string Description = "";
+    public float? MinValue;
+    public float? MaxValue;
+    public float? DefaultValue;
 }
 
 public class BitMaskInfo
@@ -131,6 +137,19 @@ public static class TemplateHelper
             case PayloadType.Float: return "Single";
             default: throw new ArgumentOutOfRangeException(nameof(payloadType));
         }
+    }
+
+    public static string GetRangeAttributeDeclaration(float? minValue, float? maxValue)
+    {
+        var minValueDeclaration = minValue.HasValue ? minValue.Value.ToString() : "float.MinValue";
+        var maxValueDeclaration = maxValue.HasValue ? maxValue.Value.ToString() : "float.MaxValue";
+        return $"[Range(min: {minValueDeclaration}, max: {maxValueDeclaration})]";
+    }
+
+    public static string GetDefaultValueAssignment(float? defaultValue, float? minValue)
+    {
+        defaultValue ??= minValue;
+        return defaultValue.HasValue? $" = {defaultValue};" : string.Empty;
     }
 
     public static string GetEventConversion(RegisterInfo register, string expression)

--- a/interface/Harp.tt
+++ b/interface/Harp.tt
@@ -1,4 +1,4 @@
-<#@ assembly name="System.Core" #>
+﻿<#@ assembly name="System.Core" #>
 <#@ import namespace="System.Linq" #>
 <#@ import namespace="System.Text" #>
 <#@ import namespace="System.Collections.Generic" #>
@@ -181,6 +181,13 @@ public static class TemplateHelper
     {
         var lsb = mask & (~mask + 1);
         return (int)Math.Log(lsb, 2);
+    }
+
+    public static string GetPayloadMemberType(PayloadMemberInfo member, PayloadType payloadType)
+    {
+        return string.IsNullOrEmpty(member.MaskType)
+            ? TemplateHelper.GetInterfaceType(payloadType)
+            : member.MaskType;
     }
 
     public static string GetPayloadMemberParser(

--- a/schema/device.json
+++ b/schema/device.json
@@ -89,6 +89,18 @@
             "description": "Specifies a custom converter method used to parse or format the payload value in the high-level interface.",
             "type": "string"
         },
+        "minValue": {
+            "description": "Specifies the minimum allowable value for the payload or payload member.",
+            "type": "number"
+        },
+        "maxValue": {
+            "description": "Specifies the maximum allowable value for the payload or payload member.",
+            "type": "number"
+        },
+        "defaultValue": {
+            "description": "Specifies the default value for the payload or payload member.",
+            "type": "number"
+        },
         "payloadMember": {
             "type": "object",
             "properties": {
@@ -105,7 +117,10 @@
                     "type": "integer"
                 },
                 "maskType": { "$ref": "#/definitions/maskType" },
-                "converter": { "$ref": "#/definitions/converter" }
+                "converter": { "$ref": "#/definitions/converter" },
+                "minValue": { "$ref": "#/definitions/minValue" },
+                "maxValue": { "$ref": "#/definitions/maxValue" },
+                "defaultValue": { "$ref": "#/definitions/defaultValue" }
             }
         },
         "register": {
@@ -138,6 +153,9 @@
                 },
                 "maskType": { "$ref": "#/definitions/maskType" },
                 "converter": { "$ref": "#/definitions/converter" },
+                "minValue": { "$ref": "#/definitions/minValue" },
+                "maxValue": { "$ref": "#/definitions/maxValue" },
+                "defaultValue": { "$ref": "#/definitions/defaultValue" },
                 "visibility": {
                     "description": "Specifies whether the register function is exposed in the high-level interface.",
                     "type": "string",

--- a/schema/device.json
+++ b/schema/device.json
@@ -81,6 +81,14 @@
             },
             "required": ["values"]
         },
+        "maskType": {
+            "description": "Specifies the name of the bit mask or group mask used to represent the payload value.",
+            "type": "string"
+        },
+        "converter": {
+            "description": "Specifies a custom converter method used to parse or format the payload value in the high-level interface.",
+            "type": "string"
+        },
         "payloadMember": {
             "type": "object",
             "properties": {
@@ -96,14 +104,8 @@
                     "description": "Specifies the payload array offset where this payload member is stored.",
                     "type": "integer"
                 },
-                "maskType": {
-                    "description": "Specifies the name of the bit mask or group mask used to represent the payload data.",
-                    "type": "string"
-                },
-                "converter": {
-                    "description": "Specifies a custom converter method used to parse or format the payload value in the high-level interface.",
-                    "type": "string"
-                }
+                "maskType": { "$ref": "#/definitions/maskType" },
+                "converter": { "$ref": "#/definitions/converter" }
             }
         },
         "register": {
@@ -134,14 +136,8 @@
                     "type": "object",
                     "additionalProperties": { "$ref": "#/definitions/payloadMember" }
                 },
-                "maskType": {
-                    "description": "Specifies the name of the bit mask or group mask used to represent the payload data.",
-                    "type": "string"
-                },
-                "converter": {
-                    "description": "Specifies a custom converter method used to parse or format the payload value in the high-level interface.",
-                    "type": "string"
-                },
+                "maskType": { "$ref": "#/definitions/maskType" },
+                "converter": { "$ref": "#/definitions/converter" },
                 "visibility": {
                     "description": "Specifies whether the register function is exposed in the high-level interface.",
                     "type": "string",


### PR DESCRIPTION
This PR refactors command creation by deconstructing the payload data into properties at the operator level. This makes it easier to use the editor property grid to fill in command default values, and allow specific editors and validation for each payload property.

Dynamic values can still be used to create commands either by using `InputMapping` or calling the register `Format` method directly.