### PR TITLE
Add support for hybrid command and event registers

### DIFF
--- a/interface/Device.tt
+++ b/interface/Device.tt
@@ -17,8 +17,13 @@ var metadataFileName = Path.Combine(metadataPath, templateFileName) + ".yml";
 
 var deviceMetadata = TemplateHelper.ReadDeviceMetadata(metadataFileName);
 var publicRegisters = deviceMetadata.Registers.Where(register => register.Value.Visibility == RegisterVisibility.Public);
-var eventMetadata = publicRegisters.Where(register => register.Value.RegisterType == RegisterType.Event).ToList();
-var commandMetadata = publicRegisters.Where(register => register.Value.RegisterType == RegisterType.Command).ToList();
+var commandMetadata = publicRegisters.Where(register => (register.Value.RegisterType & RegisterType.Command) != 0).ToList();
+var eventMetadata = publicRegisters
+    .Where(register => (register.Value.RegisterType & RegisterType.Event) != 0)
+    .Select(register => (register.Value.RegisterType & RegisterType.Command) != 0
+        ? new KeyValuePair<string, RegisterInfo>(register.Key + nameof(RegisterType.Event), register.Value)
+        : register)
+    .ToList();
 
 var deviceName = deviceMetadata.Device;
 var deviceClassName = deviceName + "Device";

--- a/interface/Device.tt
+++ b/interface/Device.tt
@@ -4,10 +4,6 @@
 <#@ import namespace="System.Linq" #>
 <#@ import namespace="System.Text" #>
 <#@ import namespace="System.Collections.Generic" #>
-<#@ assembly name="$(PkgYamlDotNet)\\lib\\net47\\YamlDotNet.dll" #>
-<#@ import namespace="YamlDotNet" #>
-<#@ import namespace="YamlDotNet.Serialization" #>
-<#@ import namespace="YamlDotNet.Serialization.NamingConventions" #>
 <#@ include file="Harp.tt" #><##>
 <#@ output extension=".Interface.cs" #>
 <#
@@ -19,20 +15,10 @@ var metadataPath = !string.IsNullOrEmpty(firmwarePath)
 var templateFileName = Path.GetFileNameWithoutExtension(Host.TemplateFile);
 var metadataFileName = Path.Combine(metadataPath, templateFileName) + ".yml";
 
-DeviceInfo deviceMetadata;
-List<KeyValuePair<string, RegisterInfo>> eventMetadata;
-List<KeyValuePair<string, RegisterInfo>> commandMetadata;
-using (var reader = new StreamReader(metadataFileName))
-{
-    var deserializer = new DeserializerBuilder()
-        .WithNamingConvention(CamelCaseNamingConvention.Instance)
-        .Build();
-
-    deviceMetadata = deserializer.Deserialize<DeviceInfo>(reader);
-    var publicRegisters = deviceMetadata.Registers.Where(register => register.Value.Visibility == RegisterVisibility.Public);
-    eventMetadata = publicRegisters.Where(register => register.Value.RegisterType == RegisterType.Event).ToList();
-    commandMetadata = publicRegisters.Where(register => register.Value.RegisterType == RegisterType.Command).ToList();
-}
+var deviceMetadata = TemplateHelper.ReadDeviceMetadata(metadataFileName);
+var publicRegisters = deviceMetadata.Registers.Where(register => register.Value.Visibility == RegisterVisibility.Public);
+var eventMetadata = publicRegisters.Where(register => register.Value.RegisterType == RegisterType.Event).ToList();
+var commandMetadata = publicRegisters.Where(register => register.Value.RegisterType == RegisterType.Command).ToList();
 
 var deviceName = deviceMetadata.Device;
 var deviceClassName = deviceName + "Device";

--- a/interface/Harp.tt
+++ b/interface/Harp.tt
@@ -1,4 +1,4 @@
-<#@ assembly name="System.Core" #>
+﻿<#@ assembly name="System.Core" #>
 <#@ import namespace="System.Linq" #>
 <#@ import namespace="System.Text" #>
 <#@ import namespace="System.Collections.Generic" #>
@@ -197,18 +197,13 @@ public static class TemplateHelper
     }
 
     public static string GetConversionFromInterfaceType(
-        string maskType,
+        string interfaceType,
         string payloadInterfaceType,
         string expression)
     {
-        var isBoolean = maskType == "bool";
-        if (!string.IsNullOrEmpty(maskType))
+        if (!string.IsNullOrEmpty(interfaceType))
         {
-            if (isBoolean) expression = $"({expression} ? 1 : 0)";
-            else expression = $"({payloadInterfaceType}){expression}";
-        }
-        if (isBoolean)
-        {
+            if (interfaceType == "bool") expression = $"({expression} ? 1 : 0)";
             expression = $"({payloadInterfaceType}){expression}";
         }
         return expression;
@@ -275,10 +270,14 @@ public static class TemplateHelper
         var payloadInterfaceType = GetInterfaceType(payloadType);
         if (!string.IsNullOrEmpty(member.MaskType))
         {
-            if (isBoolean) expression = $"({expression} ? 1 : 0)";
-            else expression = $"({payloadInterfaceType}){expression}";
+            if (isBoolean)
+            {
+                var bitValue = member.Mask.HasValue ? $"0x{member.Mask.Value.ToString("X")}" : "1";
+                expression = $"({expression} ? {bitValue} : 0)";
+            }
+            expression = $"({payloadInterfaceType}){expression}";
         }
-        if (member.Mask.HasValue)
+        if (member.Mask.HasValue && !isBoolean)
         {
             var mask = member.Mask.Value;
             var shift = GetMaskShift(mask);
@@ -288,10 +287,6 @@ public static class TemplateHelper
             }
 
             expression = $"({payloadInterfaceType})({expression} & 0x{mask.ToString("X")})";
-        }
-        else if (isBoolean)
-        {
-            expression = $"({payloadInterfaceType}){expression}";
         }
         
         if (member.Mask.HasValue && assigned)

--- a/interface/Harp.tt
+++ b/interface/Harp.tt
@@ -5,6 +5,8 @@
 <#@ assembly name="$(PkgBonsai_Harp)\\lib\\net462\\Bonsai.Harp.dll" #>
 <#@ assembly name="$(PkgYamlDotNet)\\lib\\net47\\YamlDotNet.dll" #>
 <#@ import namespace="YamlDotNet" #>
+<#@ import namespace="YamlDotNet.Core" #>
+<#@ import namespace="YamlDotNet.Core.Events" #>
 <#@ import namespace="YamlDotNet.Serialization" #>
 <#@ import namespace="YamlDotNet.Serialization.NamingConventions" #>
 <#@ import namespace="Bonsai.Harp" #>
@@ -87,6 +89,7 @@ public static class TemplateHelper
         {
             var deserializer = new DeserializerBuilder()
                 .WithNamingConvention(CamelCaseNamingConvention.Instance)
+                .WithTypeConverter(RegisterTypeConverter.Instance)
                 .Build();
             return deserializer.Deserialize<DeviceInfo>(reader);
         }
@@ -296,6 +299,52 @@ public static class TemplateHelper
             return $" |= {expression}";
         }
         else return $" = {expression}";
+    }
+}
+
+class RegisterTypeConverter : IYamlTypeConverter
+{
+    public static RegisterTypeConverter Instance = new RegisterTypeConverter();
+
+    public bool Accepts(Type type)
+    {
+        return type == typeof(RegisterType);
+    }
+
+    public object ReadYaml(IParser parser, Type type)
+    {
+        if (parser.TryConsume(out SequenceStart _))
+        {
+            RegisterType value = default;
+            while (parser.TryConsume(out Scalar scalar))
+            {
+                value |= (RegisterType)Enum.Parse(typeof(RegisterType), scalar.Value);
+            }
+            parser.Consume<SequenceEnd>();
+            return value;
+        }
+        else
+        {
+            var scalar = parser.Consume<Scalar>();
+            return (RegisterType)Enum.Parse(typeof(RegisterType), scalar.Value);
+        }
+    }
+
+    public void WriteYaml(IEmitter emitter, object value, Type type)
+    {
+        var registerType = (RegisterType)value;
+        if (registerType == (RegisterType.Command | RegisterType.Event))
+        {
+            emitter.Emit(new SequenceStart(AnchorName.Empty, TagName.Empty, isImplicit: true, SequenceStyle.Flow));
+            emitter.Emit(new Scalar(RegisterType.Command.ToString()));
+            emitter.Emit(new Scalar(RegisterType.Event.ToString()));
+            emitter.Emit(new SequenceEnd());
+        }
+        else
+        {
+            var scalar = new Scalar(registerType.ToString());
+            emitter.Emit(scalar);
+        }
     }
 }
 #>

--- a/interface/Harp.tt
+++ b/interface/Harp.tt
@@ -1,8 +1,12 @@
-﻿<#@ assembly name="System.Core" #>
+<#@ assembly name="System.Core" #>
 <#@ import namespace="System.Linq" #>
 <#@ import namespace="System.Text" #>
 <#@ import namespace="System.Collections.Generic" #>
 <#@ assembly name="$(PkgBonsai_Harp)\\lib\\net462\\Bonsai.Harp.dll" #>
+<#@ assembly name="$(PkgYamlDotNet)\\lib\\net47\\YamlDotNet.dll" #>
+<#@ import namespace="YamlDotNet" #>
+<#@ import namespace="YamlDotNet.Serialization" #>
+<#@ import namespace="YamlDotNet.Serialization.NamingConventions" #>
 <#@ import namespace="Bonsai.Harp" #>
 <#+
 public class DeviceInfo
@@ -77,6 +81,17 @@ public class GroupMaskInfo
 
 public static class TemplateHelper
 {
+    public static DeviceInfo ReadDeviceMetadata(string path)
+    {
+        using (var reader = new StreamReader(path))
+        {
+            var deserializer = new DeserializerBuilder()
+                .WithNamingConvention(CamelCaseNamingConvention.Instance)
+                .Build();
+            return deserializer.Deserialize<DeviceInfo>(reader);
+        }
+    }
+
     public static string GetInterfaceType(string name, RegisterInfo register)
     {
         if (register.PayloadSpec != null) return $"{name}Payload";

--- a/schema/device.json
+++ b/schema/device.json
@@ -51,6 +51,10 @@
             "type": "string",
             "enum": ["U8", "S8", "U16", "S16", "U32", "S32", "U64", "S64", "Float"]
         },
+        "registerType": {
+            "type": "string",
+            "enum": ["Command", "Event"]
+        },
         "bitMask": {
             "description": "Specifies a bit mask used for reading or writing specific registers.",
             "type": "object",
@@ -138,8 +142,16 @@
                 },
                 "registerType": {
                     "description": "Specifies the expected use of the register.",
-                    "type": "string",
-                    "enum": ["Command", "Event"]
+                    "oneOf": [
+                        { "$ref": "#/definitions/registerType" },
+                        {
+                            "type": "array",
+                            "items": { "$ref": "#/definitions/registerType" },
+                            "uniqueItems": true,
+                            "minItems": 1,
+                            "maxItems": 2
+                        }
+                    ]
                 },
                 "payloadType": { "$ref": "#/definitions/payloadType" },
                 "payloadLength": {


### PR DESCRIPTION
This PR adds generator support for handling registers with both command and event functionality. To avoid the name clash between the two operators with the same name, the text template adds the suffix `Event` to the operator handling the event payloads.