### PR TITLE
Split specification of high-level interface type

### DIFF
--- a/interface/Device.tt
+++ b/interface/Device.tt
@@ -265,7 +265,7 @@ foreach (var registerMetadata in commandMetadata)
     {
         foreach (var member in register.PayloadSpec)
         {
-            var memberType = TemplateHelper.GetPayloadMemberType(member.Value, register.PayloadType);
+            var memberType = TemplateHelper.GetInterfaceType(member.Value, register.PayloadType);
             defaultValue = TemplateHelper.GetDefaultValueAssignment(member.Value.DefaultValue, member.Value.MinValue);
             var memberDescription = string.IsNullOrEmpty(member.Value.Description)
                 ? $"to write on payload member {member.Key}"
@@ -416,16 +416,17 @@ foreach (var registerMetadata in deviceMetadata.Registers)
 {
     var register = registerMetadata.Value;
     if (register.PayloadSpec == null) continue;
+    var interfaceType = TemplateHelper.GetInterfaceType(registerMetadata.Key, register);
 #>
 
     /// <summary>
     /// Represents the payload of the <#= registerMetadata.Key #> register.
     /// </summary>
-    public struct <#= registerMetadata.Key #>Payload
+    public struct <#= interfaceType #>
     {<#
     foreach (var member in register.PayloadSpec)
     {
-        var memberType = TemplateHelper.GetPayloadMemberType(member.Value, register.PayloadType);
+        var memberType = TemplateHelper.GetInterfaceType(member.Value, register.PayloadType);
 #>
 
         /// <summary>

--- a/interface/Harp.tt
+++ b/interface/Harp.tt
@@ -45,6 +45,7 @@ public class RegisterInfo
     public Dictionary<string, PayloadMemberInfo> PayloadSpec;
     public RegisterVisibility Visibility;
     public string MaskType;
+    public string InterfaceType;
     public string Converter;
     public float? MinValue;
     public float? MaxValue;
@@ -58,6 +59,7 @@ public class PayloadMemberInfo
     public int? Mask;
     public int? Offset;
     public string MaskType;
+    public string InterfaceType;
     public string Converter;
     public string Description = "";
     public float? MinValue;
@@ -97,9 +99,17 @@ public static class TemplateHelper
 
     public static string GetInterfaceType(string name, RegisterInfo register)
     {
-        if (register.PayloadSpec != null) return $"{name}Payload";
+        if (!string.IsNullOrEmpty(register.InterfaceType)) return register.InterfaceType;
+        else if (register.PayloadSpec != null) return $"{name}Payload";
         else if (!string.IsNullOrEmpty(register.MaskType)) return register.MaskType;
         else return GetInterfaceType(register.PayloadType, register.PayloadLength);
+    }
+
+    public static string GetInterfaceType(PayloadMemberInfo member, PayloadType payloadType)
+    {
+        if (!string.IsNullOrEmpty(member.InterfaceType)) return member.InterfaceType;
+        else if (!string.IsNullOrEmpty(member.MaskType)) return member.MaskType;
+        else return GetInterfaceType(payloadType);
     }
 
     public static string GetInterfaceType(PayloadType payloadType)
@@ -175,7 +185,7 @@ public static class TemplateHelper
         var converter = register.Converter;
         if (!string.IsNullOrEmpty(converter)) return $"{converter}({expression})";
         if (register.PayloadSpec != null) return $"ParsePayload({expression})";
-        return GetConversionToMaskType(register.MaskType, expression);
+        return GetConversionToInterfaceType(register.InterfaceType ?? register.MaskType, expression);
     }
 
     public static string GetCommandConversion(RegisterInfo register, string expression)
@@ -183,16 +193,16 @@ public static class TemplateHelper
         var converter = register.Converter;
         if (!string.IsNullOrEmpty(converter)) return $"{converter}({expression})";
         if (register.PayloadSpec != null) return $"FormatPayload({expression})";
-        return GetConversionFromInterfaceType(register.MaskType, register.PayloadInterfaceType, expression);
+        return GetConversionFromInterfaceType(register.InterfaceType ?? register.MaskType, register.PayloadInterfaceType, expression);
     }
 
-    public static string GetConversionToMaskType(string maskType, string expression)
+    public static string GetConversionToInterfaceType(string interfaceType, string expression)
     {
-        if (string.IsNullOrEmpty(maskType)) return expression;
-        switch (maskType)
+        if (string.IsNullOrEmpty(interfaceType)) return expression;
+        switch (interfaceType)
         {
             case "bool": return $"{expression} != 0";
-            default: return $"({maskType}){expression}";
+            default: return $"({interfaceType}){expression}";
         }
     }
 
@@ -215,13 +225,6 @@ public static class TemplateHelper
         return (int)Math.Log(lsb, 2);
     }
 
-    public static string GetPayloadMemberType(PayloadMemberInfo member, PayloadType payloadType)
-    {
-        return string.IsNullOrEmpty(member.MaskType)
-            ? TemplateHelper.GetInterfaceType(payloadType)
-            : member.MaskType;
-    }
-
     public static string GetPayloadMemberParser(
         PayloadMemberInfo member,
         string expression,
@@ -236,7 +239,7 @@ public static class TemplateHelper
             var mask = member.Mask.Value;
             var shift = GetMaskShift(mask);
             expression = $"({expression} & 0x{mask.ToString("X")})";
-            if (member.MaskType != "bool")
+            if (member.InterfaceType != "bool")
             {
                 if (shift > 0)
                 {
@@ -248,7 +251,7 @@ public static class TemplateHelper
             }
         }
 
-        expression = GetConversionToMaskType(member.MaskType, expression);
+        expression = GetConversionToInterfaceType(member.InterfaceType ?? member.MaskType, expression);
         if (!string.IsNullOrEmpty(member.Converter))
         {
             expression = $"{member.Converter}({expression})";
@@ -266,9 +269,9 @@ public static class TemplateHelper
         {
             expression = $"{member.Converter}({expression})";
         }
-        var isBoolean = member.MaskType == "bool";
+        var isBoolean = member.InterfaceType == "bool";
         var payloadInterfaceType = GetInterfaceType(payloadType);
-        if (!string.IsNullOrEmpty(member.MaskType))
+        if (!string.IsNullOrEmpty(member.InterfaceType ?? member.MaskType))
         {
             if (isBoolean)
             {

--- a/schema/device.json
+++ b/schema/device.json
@@ -89,6 +89,10 @@
             "description": "Specifies the name of the bit mask or group mask used to represent the payload value.",
             "type": "string"
         },
+        "interfaceType": {
+            "description": "Specifies the name of the type used to represent the payload value in the high-level interface.",
+            "type": "string"
+        },
         "converter": {
             "description": "Specifies a custom converter method used to parse or format the payload value in the high-level interface.",
             "type": "string"
@@ -121,6 +125,7 @@
                     "type": "integer"
                 },
                 "maskType": { "$ref": "#/definitions/maskType" },
+                "interfaceType": { "$ref": "#/definitions/interfaceType" },
                 "converter": { "$ref": "#/definitions/converter" },
                 "minValue": { "$ref": "#/definitions/minValue" },
                 "maxValue": { "$ref": "#/definitions/maxValue" },
@@ -164,6 +169,7 @@
                     "additionalProperties": { "$ref": "#/definitions/payloadMember" }
                 },
                 "maskType": { "$ref": "#/definitions/maskType" },
+                "interfaceType": { "$ref": "#/definitions/interfaceType" },
                 "converter": { "$ref": "#/definitions/converter" },
                 "minValue": { "$ref": "#/definitions/minValue" },
                 "maxValue": { "$ref": "#/definitions/maxValue" },


### PR DESCRIPTION
This PR adds support for specifying the high-level interface types separate from mask types. This will be convenient for validating firmware generation independently of interface generation. A new attribute `interfaceType` is added to the device metadata to indicate the high-level type name.

If both `payloadSpec` and `interfaceType` attributes are specified, `interfaceType` is used to generate the name of the payload class.