### PR TITLE
Move IO pin configuration into separate schema

### DIFF
--- a/schema/device.json
+++ b/schema/device.json
@@ -37,11 +37,6 @@
             "type": "object",
             "description": "Specifies the collection of group masks available to be used with the different registers.",
             "additionalProperties": { "$ref": "#/definitions/groupMask" }
-        },
-        "ios": {
-            "type": "object",
-            "description": "Specifies the IO pin configuration used to automatically generate the firmware.",
-            "additionalProperties": { "$ref": "#/definitions/pinMapping" }
         }
     },
     "required": ["device", "whoAmI", "firmwareVersion", "hardwareTargets", "registers"],
@@ -185,66 +180,6 @@
                 }
             },
             "required": ["address", "registerType", "payloadType"]
-        },
-        "pinMapping": {
-            "type": "object",
-            "properties": {
-                "description": {
-                    "description": "Specifies a summary description of the IO function.",
-                    "type": "string"
-                },
-                "port": {
-                    "description": "Specifies the microcontroller port.",
-                    "type": "string"
-                },
-                "pin": {
-                    "description": "Specifies the unique pin number in the defined port.",
-                    "type": "integer"
-                },
-                "direction": {
-                    "description": "Specifies whether the pin will be used as input or output.",
-                    "type": "string",
-                    "enum": ["input", "output"]
-                },
-                "useInput": {
-                    "description": "Specifies whether the output pin can also read its state from the input `mode`",
-                    "type": "boolean"
-                },
-                "pull": {
-                    "description": " JUST FOR INPUTS ... Specifies the state of the pin input pull, or latch, circuit.",
-                    "type": "string",
-                    "enum": ["up", "down", "tristate", "busholder"]
-                },
-                "sense":{
-                    "description": "Specifies event a digital input pin is sensitive to.",
-                    "type": "string",
-                    "enum": ["both", "rising", "falling", "low", "none"]
-                },
-                "interruptPriority": {
-                    "description": "Specifies the priority of the interrupt event for this pin.",
-                    "type": "string",
-                    "enum": ["low", "med", "high", "off"]
-                },
-                "interruptNumber":{
-                    "description": "Specifies the interrupt number associated with the specific pin.",
-                    "type": "integer",
-                    "enum": [0, 1]
-                },
-                "out":{
-                    "description": "ONLY OUTPUTS. Specifies output mode of the pin.",
-                    "type": "string",
-                    "enum": ["digital", "wireOr", "wireAnd", "wiredOrPull", "wiredAndPull"]
-                },
-                "outDefault":{
-                    "description": "Specifies the initial state of the output line at boot time.",
-                    "enum": [0, 1]
-                },
-                "outInvert":{
-                    "description": "Specifies whether the output should be inverted.",
-                    "type": "boolean"
-                }
-            },
-            "required": ["port", "pin", "direction"]
         }
     }
 }

--- a/schema/ios.json
+++ b/schema/ios.json
@@ -1,0 +1,90 @@
+{
+    "$schema": "https://json-schema.org/draft-07/schema",
+    "$id": "https://harp-tech.org/2023-02/ios",
+    "type": "object",
+    "description": "Specifies the IO pin configuration used to automatically generate firmware.",
+    "additionalProperties": {
+        "oneOf": [
+            { "$ref": "#/definitions/inputPin" },
+            { "$ref": "#/definitions/outputPin" }
+        ]
+    },
+    "definitions": {
+        "portPin": {
+            "type": "object",
+            "properties": {
+                "description": {
+                    "description": "Specifies a summary description of the IO pin function.",
+                    "type": "string"
+                },
+                "port": {
+                    "description": "Specifies the microcontroller port where the pin is located.",
+                    "type": "string"
+                },
+                "pinNumber": {
+                    "description": "Specifies the unique pin number in the defined port.",
+                    "type": "integer"
+                },
+                "direction": {
+                    "description": "Specifies whether the pin will be used as input or output.",
+                    "type": "string",
+                    "enum": ["input", "output"]
+                }
+            },
+            "required": ["port", "pinNumber", "direction"]
+        },
+        "inputPin": {
+            "allOf": [{ "$ref": "#/definitions/portPin" }],
+            "properties": {
+                "direction": {
+                    "enum": ["input"]
+                },
+                "pinMode": {
+                    "description": "Specifies how the input pin is configured to handle floating inputs.",
+                    "type": "string",
+                    "enum": ["pullup", "pulldown", "tristate", "busholder"]
+                },
+                "triggerMode": {
+                    "description": "Specifies when the interrupt event for this pin should be triggered.",
+                    "type": "string",
+                    "enum": ["none", "rising", "falling", "toggle", "low"]
+                },
+                "interruptPriority": {
+                    "description": "Specifies the priority of the interrupt event for this pin.",
+                    "type": "string",
+                    "enum": ["off", "low", "medium", "high"]
+                },
+                "interruptNumber": {
+                    "description": "Specifies the interrupt number associated with this pin.",
+                    "type": "integer",
+                    "enum": [0, 1]
+                }
+            }
+        },
+        "outputPin": {
+            "allOf": [{ "$ref": "#/definitions/portPin" }],
+            "properties": {
+                "direction": {
+                    "enum": ["output"]
+                },
+                "allowRead": {
+                    "description": "Specifies whether reading the state of the output pin is allowed.",
+                    "type": "boolean"
+                },
+                "pinMode": {
+                    "description": "Specifies the output pin wiring configuration.",
+                    "type": "string",
+                    "enum": ["wiredOr", "wiredAnd", "wiredOrPull", "wiredAndPull"]
+                },
+                "initialState": {
+                    "description": "Specifies the initial state of the output pin at boot time.",
+                    "enum": ["low", "high"]
+                },
+                "invert": {
+                    "description": "Specifies whether the output logic of the pin should be inverted.",
+                    "type": "boolean"
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
This PR splits the IO pin configuration into a separate schema to allow keeping device implementation details away from the high-level interface specification.

This should also make it easier to design modular schemas for microcontroller firmware architectures other than AVR, such as MicroPython.