### PR TITLE
Support description for individual mask values

### DIFF
--- a/interface/Device.tt
+++ b/interface/Device.tt
@@ -456,8 +456,20 @@ foreach (var bitMask in deviceMetadata.BitMasks)
     var bitIndex = 0;
     foreach (var bitField in mask.Bits)
     {
+        var fieldInfo = bitField.Value;
 #>
-        <#= bitField.Key #> = 0x<#= bitField.Value.ToString("X") #><#= ++bitIndex < mask.Bits.Count ? "," : string.Empty #>
+<#
+        if (!string.IsNullOrEmpty(fieldInfo.Description))
+        {
+            if (bitIndex > 0) WriteLine("");
+#>
+        /// <summary>
+        /// <#= fieldInfo.Description #>
+        /// </summary>
+<#
+        }
+#>
+        <#= bitField.Key #> = 0x<#= fieldInfo.Value.ToString("X") #><#= ++bitIndex < mask.Bits.Count ? "," : string.Empty #>
 <#
     }
 #>
@@ -480,8 +492,20 @@ foreach (var groupMask in deviceMetadata.GroupMasks)
     var memberIndex = 0;
     foreach (var member in mask.Values)
     {
+        var memberInfo = member.Value;
 #>
-        <#= member.Key #> = <#= member.Value #><#= ++memberIndex < mask.Values.Count ? "," : string.Empty #>
+<#
+        if (!string.IsNullOrEmpty(memberInfo.Description))
+        {
+            if (memberIndex > 0) WriteLine("");
+#>
+        /// <summary>
+        /// <#= memberInfo.Description #>
+        /// </summary>
+<#
+        }
+#>
+        <#= member.Key #> = <#= memberInfo.Value #><#= ++memberIndex < mask.Values.Count ? "," : string.Empty #>
 <#
     }
 #>

--- a/interface/Harp.tt
+++ b/interface/Harp.tt
@@ -70,7 +70,7 @@ public class PayloadMemberInfo
 public class BitMaskInfo
 {
     public string Description = "";
-    public Dictionary<string, int> Bits = new Dictionary<string, int>();
+    public Dictionary<string, MaskValue> Bits = new Dictionary<string, MaskValue>();
 
     public string InterfaceType => TemplateHelper.GetInterfaceType(Bits);
 }
@@ -78,9 +78,15 @@ public class BitMaskInfo
 public class GroupMaskInfo
 {
     public string Description = "";
-    public Dictionary<string, int> Values = new Dictionary<string, int>();
+    public Dictionary<string, MaskValue> Values = new Dictionary<string, MaskValue>();
 
     public string InterfaceType => TemplateHelper.GetInterfaceType(Values);
+}
+
+public class MaskValue
+{
+    public int Value;
+    public string Description;
 }
 
 public static class TemplateHelper
@@ -92,6 +98,7 @@ public static class TemplateHelper
             var deserializer = new DeserializerBuilder()
                 .WithNamingConvention(CamelCaseNamingConvention.Instance)
                 .WithTypeConverter(RegisterTypeConverter.Instance)
+                .WithTypeConverter(MaskValueTypeConverter.Instance)
                 .Build();
             return deserializer.Deserialize<DeviceInfo>(reader);
         }
@@ -136,9 +143,9 @@ public static class TemplateHelper
         else return baseType;
     }
 
-    public static string GetInterfaceType(Dictionary<string, int> maskValues)
+    public static string GetInterfaceType(Dictionary<string, MaskValue> maskValues)
     {
-        var max = maskValues.Values.Max();
+        var max = maskValues.Values.Max(field => field.Value);
         if (max <= byte.MaxValue) return "byte";
         if (max <= ushort.MaxValue) return "ushort";
         else return "uint";
@@ -300,6 +307,49 @@ public static class TemplateHelper
     }
 }
 
+class MaskValueTypeConverter : IYamlTypeConverter
+{
+    public static MaskValueTypeConverter Instance = new MaskValueTypeConverter();
+    static readonly IDeserializer ValueDeserializer = new Deserializer();
+
+    public bool Accepts(Type type)
+    {
+        return type == typeof(MaskValue);
+    }
+
+    public object ReadYaml(IParser parser, Type type)
+    {
+        if (parser.TryConsume(out MappingStart _))
+        {
+            var maskValue = new MaskValue();
+            while (!parser.TryConsume(out MappingEnd _))
+            {
+                var key = parser.Consume<Scalar>();
+                var value = parser.Consume<Scalar>();
+                if (string.IsNullOrEmpty(value.Value))
+                {
+                    maskValue.Value = ValueDeserializer.Deserialize<int>(key.Value);
+                }
+                else if (key.Value.Equals(nameof(maskValue.Description), StringComparison.OrdinalIgnoreCase))
+                {
+                    maskValue.Description = value.Value;
+                }
+            }
+            return maskValue;
+        }
+        else
+        {
+            var scalar = parser.Consume<Scalar>();
+            return new MaskValue { Value = ValueDeserializer.Deserialize<int>(scalar.Value) };
+        }
+    }
+
+    public void WriteYaml(IEmitter emitter, object value, Type type)
+    {
+        throw new NotImplementedException();
+    }
+}
+
 class RegisterTypeConverter : IYamlTypeConverter
 {
     public static RegisterTypeConverter Instance = new RegisterTypeConverter();
@@ -330,19 +380,7 @@ class RegisterTypeConverter : IYamlTypeConverter
 
     public void WriteYaml(IEmitter emitter, object value, Type type)
     {
-        var registerType = (RegisterType)value;
-        if (registerType == (RegisterType.Command | RegisterType.Event))
-        {
-            emitter.Emit(new SequenceStart(AnchorName.Empty, TagName.Empty, isImplicit: true, SequenceStyle.Flow));
-            emitter.Emit(new Scalar(RegisterType.Command.ToString()));
-            emitter.Emit(new Scalar(RegisterType.Event.ToString()));
-            emitter.Emit(new SequenceEnd());
-        }
-        else
-        {
-            var scalar = new Scalar(registerType.ToString());
-            emitter.Emit(scalar);
-        }
+        throw new NotImplementedException();
     }
 }
 #>

--- a/schema/device.json
+++ b/schema/device.json
@@ -50,6 +50,21 @@
             "type": "string",
             "enum": ["Command", "Event"]
         },
+        "maskValue": {
+            "oneOf": [
+                { "type": "integer" },
+                {
+                    "type": "object",
+                    "properties": {
+                        "description": {
+                            "description": "Specifies a summary description of the mask value function.",
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false
+                }
+            ]
+        },
         "bitMask": {
             "description": "Specifies a bit mask used for reading or writing specific registers.",
             "type": "object",
@@ -60,7 +75,7 @@
                 },
                 "bits": {
                     "type": "object",
-                    "additionalProperties": { "type": "integer" }
+                    "additionalProperties": { "$ref": "#/definitions/maskValue" }
                 }
             },
             "required": ["bits"]
@@ -75,7 +90,7 @@
                 },
                 "values": {
                     "type": "object",
-                    "additionalProperties": { "type": "integer" }
+                    "additionalProperties": { "$ref": "#/definitions/maskValue" }
                 }
             },
             "required": ["values"]

--- a/schema/example.yml
+++ b/schema/example.yml
@@ -72,16 +72,5 @@ bitMasks:
   DO:
     description: Bitmask representing the state of the digital outputs.
     bits:
-      DO0: 0x01
-      DO1: 0x02
-ios:
-  DO3:
-    port: PORTC
-    pin: 0
-    direction: output
-    description: DO0
-  DO2:
-    port: PORTB
-    pin: 2
-    direction: output
-    description: DO0
+      DO0: {0x01, description: The state of digital output pin 0.}
+      DO1: {0x02, description: The state of digital output pin 1.}


### PR DESCRIPTION
This PR adds support for descriptions on individual bit mask or group mask values. To increase readability, this is done by exploiting the ability of YAML to have non-string keys in object mappings, example below:

```yml
bitMask:
  PortState:
    Port0:  0x1 # this is allowed
    Port1: {0x2, description: Specifies the state of port 1.} # this is also allowed
```

This works well with JSON-schema even though JSON only supports string keys, but does create a slightly unconventional schema, and does not allow validation on the type of the key (i.e. `Port1: {hello, description: Specifies the state of port 1.}` would also be "accepted" by the schema (but fail at generation time).

The alternative would be:

```yml
bitMask:
  PortState:
    Port0:  0x1 # this is allowed
    Port1: {value: 0x2, description: Specifies the state of port 1.} # this is also allowed
```

Which is more verbose, but uses only JSON-schema compatible constructs.

This PR assumes the former, as it is more similar to how bitmasks are defined in code (value / comment pairs) and generation is validating all inputs anyway.