### PR TITLE
Split schema into device and register interface

### DIFF
--- a/interface/Device.tt
+++ b/interface/Device.tt
@@ -13,11 +13,11 @@ var metadataPath = !string.IsNullOrEmpty(firmwarePath)
     ? Host.ResolvePath(firmwarePath)
     : Path.GetDirectoryName(Host.TemplateFile);
 var templateFileName = Path.GetFileNameWithoutExtension(Host.TemplateFile);
-var metadataFileName = Path.Combine(metadataPath, templateFileName) + ".yml";
+var metadataFileName = Path.Combine(metadataPath, "device.yml");
 
 var deviceMetadata = TemplateHelper.ReadDeviceMetadata(metadataFileName);
 var publicRegisters = deviceMetadata.Registers.Where(register => register.Value.Visibility == RegisterVisibility.Public).ToList();
-var writeRegisters = publicRegisters.Where(register => (register.Value.RegisterType & RegisterType.Write) != 0).ToList();
+var writeRegisters = publicRegisters.Where(register => (register.Value.Access & RegisterAccess.Write) != 0).ToList();
 var deviceName = deviceMetadata.Device;
 #>
 using Bonsai;
@@ -134,11 +134,11 @@ foreach (var register in publicRegisters)
 foreach (var registerMetadata in publicRegisters)
 {
     var register = registerMetadata.Value;
-    var hasEvent = (register.RegisterType & RegisterType.Event) != 0;
-    var allowWrite = (register.RegisterType & RegisterType.Write) != 0;
+    var hasEvent = (register.Access & RegisterAccess.Event) != 0;
+    var allowWrite = (register.Access & RegisterAccess.Write) != 0;
     var defaultMessageType = hasEvent ? "Event" : (allowWrite ? "Write" : "Read");
     var interfaceType = TemplateHelper.GetInterfaceType(registerMetadata.Key, register);
-    var parsePayloadSuffix = TemplateHelper.GetPayloadTypeSuffix(register.PayloadType, register.PayloadLength);
+    var parsePayloadSuffix = TemplateHelper.GetPayloadTypeSuffix(register.Type, register.Length);
     var parsePayloadSelector = $"message.GetPayload{parsePayloadSuffix}()";
     var parseConversion = TemplateHelper.GetEventConversion(register, parsePayloadSelector);
 
@@ -146,7 +146,7 @@ foreach (var registerMetadata in publicRegisters)
     var timestampedPayloadSelector = $"message.GetTimestampedPayload{parsePayloadSuffix}()";
     var timestampedParseConversion = TemplateHelper.GetEventConversion(register, payloadValueSelector);
 
-    var formatPayloadSuffix = TemplateHelper.GetPayloadTypeSuffix(register.PayloadType);
+    var formatPayloadSuffix = TemplateHelper.GetPayloadTypeSuffix(register.Type);
     var formatConversion = TemplateHelper.GetCommandConversion(register, "value");
     var summaryDescription = string.IsNullOrEmpty(register.Description)
         ? $"manipulates messages from register {registerMetadata.Key}"
@@ -191,7 +191,7 @@ foreach (var registerMetadata in publicRegisters)
             var memberConversion = TemplateHelper.GetPayloadMemberParser(
                 member.Value,
                 "payload",
-                register.PayloadType);
+                register.Type);
 #>
             result.<#= member.Key #> = <#= memberConversion #>;
 <#
@@ -210,15 +210,15 @@ foreach (var registerMetadata in publicRegisters)
         {
             <#= register.PayloadInterfaceType #> result;
 <#
-        if (register.PayloadLength > 0)
+        if (register.Length > 0)
         {
 #>
-            result = new <#= TemplateHelper.GetInterfaceType(register.PayloadType) #>[<#= register.PayloadLength #>];
+            result = new <#= TemplateHelper.GetInterfaceType(register.Type) #>[<#= register.Length #>];
 <#
         }
 #>
 <#
-        var assigned = new bool[Math.Max(1, register.PayloadLength)];
+        var assigned = new bool[Math.Max(1, register.Length)];
         foreach (var member in register.PayloadSpec)
         {
             var payloadIndex = member.Value.Offset.GetValueOrDefault(0);
@@ -226,7 +226,7 @@ foreach (var registerMetadata in publicRegisters)
             var memberConversion = TemplateHelper.GetPayloadMemberFormatter(
                 member.Value,
                 $"value.{member.Key}",
-                register.PayloadType,
+                register.Type,
                 assigned[payloadIndex]);
             assigned[payloadIndex] = true;
 #>
@@ -434,7 +434,7 @@ foreach (var registerMetadata in writeRegisters)
     {
         foreach (var member in register.PayloadSpec)
         {
-            var memberType = TemplateHelper.GetInterfaceType(member.Value, register.PayloadType);
+            var memberType = TemplateHelper.GetInterfaceType(member.Value, register.Type);
             defaultValue = TemplateHelper.GetDefaultValueAssignment(member.Value.DefaultValue, member.Value.MinValue);
             var memberDescription = string.IsNullOrEmpty(member.Value.Description)
                 ? $"to write on payload member {member.Key}"
@@ -543,7 +543,7 @@ foreach (var registerMetadata in deviceMetadata.Registers)
     {<#
     foreach (var member in register.PayloadSpec)
     {
-        var memberType = TemplateHelper.GetInterfaceType(member.Value, register.PayloadType);
+        var memberType = TemplateHelper.GetInterfaceType(member.Value, register.Type);
 #>
 
         /// <summary>

--- a/interface/Firmware.tt
+++ b/interface/Firmware.tt
@@ -101,8 +101,8 @@ foreach (var registerMetadata in deviceMetadata.Registers)
 {
     var register = registerMetadata.Value;
     var registerName = FirmwareNamingConvention.Instance.Apply(registerMetadata.Key);
-    var arrayType = register.PayloadLength > 0 ? $"[{register.PayloadLength}]" : string.Empty;
-    var firmwareType = TemplateHelper.GetFirmwareType(register.PayloadType);
+    var arrayType = register.Length > 0 ? $"[{register.Length}]" : string.Empty;
+    var firmwareType = TemplateHelper.GetFirmwareType(register.Type);
 #>
     <#= firmwareType #> REG_<#= registerName #><#= arrayType #>;
 <#
@@ -120,7 +120,7 @@ foreach (var registerMetadata in deviceMetadata.Registers)
     var registerName = FirmwareNamingConvention.Instance.Apply(registerMetadata.Key);
     var register = registerMetadata.Value;
 #>
-#define ADD_REG_<#= registerName #>      <#= register.Address #> // <#= register.PayloadType #>    <#= register.Description #>
+#define ADD_REG_<#= registerName #>      <#= register.Address #> // <#= register.Type #>    <#= register.Description #>
 <#
 }
 #>

--- a/interface/Interface.tt
+++ b/interface/Interface.tt
@@ -23,7 +23,7 @@ public class DeviceInfo
 }
 
 [Flags]
-public enum RegisterType
+public enum RegisterAccess
 {
     Read = 0x1,
     Write = 0x2,
@@ -40,9 +40,9 @@ public class RegisterInfo
 {
     public int Address;
     public string Description = "";
-    public RegisterType RegisterType = RegisterType.Read;
-    public PayloadType PayloadType;
-    public int PayloadLength;
+    public RegisterAccess Access = RegisterAccess.Read;
+    public PayloadType Type;
+    public int Length;
     public Dictionary<string, PayloadMemberInfo> PayloadSpec;
     public RegisterVisibility Visibility;
     public string MaskType;
@@ -52,7 +52,7 @@ public class RegisterInfo
     public float? MaxValue;
     public float? DefaultValue;
 
-    public string PayloadInterfaceType => TemplateHelper.GetInterfaceType(PayloadType, PayloadLength);
+    public string PayloadInterfaceType => TemplateHelper.GetInterfaceType(Type, Length);
 }
 
 public class PayloadMemberInfo
@@ -98,7 +98,7 @@ public static partial class TemplateHelper
         {
             var deserializer = new DeserializerBuilder()
                 .WithNamingConvention(CamelCaseNamingConvention.Instance)
-                .WithTypeConverter(RegisterTypeConverter.Instance)
+                .WithTypeConverter(RegisterAccessTypeConverter.Instance)
                 .WithTypeConverter(MaskValueTypeConverter.Instance)
                 .Build();
             return deserializer.Deserialize<DeviceInfo>(reader);
@@ -110,7 +110,7 @@ public static partial class TemplateHelper
         if (!string.IsNullOrEmpty(register.InterfaceType)) return register.InterfaceType;
         else if (register.PayloadSpec != null) return $"{name}Payload";
         else if (!string.IsNullOrEmpty(register.MaskType)) return register.MaskType;
-        else return GetInterfaceType(register.PayloadType, register.PayloadLength);
+        else return GetInterfaceType(register.Type, register.Length);
     }
 
     public static string GetInterfaceType(PayloadMemberInfo member, PayloadType payloadType)
@@ -351,23 +351,23 @@ class MaskValueTypeConverter : IYamlTypeConverter
     }
 }
 
-class RegisterTypeConverter : IYamlTypeConverter
+class RegisterAccessTypeConverter : IYamlTypeConverter
 {
-    public static RegisterTypeConverter Instance = new RegisterTypeConverter();
+    public static RegisterAccessTypeConverter Instance = new RegisterAccessTypeConverter();
 
     public bool Accepts(Type type)
     {
-        return type == typeof(RegisterType);
+        return type == typeof(RegisterAccess);
     }
 
     public object ReadYaml(IParser parser, Type type)
     {
         if (parser.TryConsume(out SequenceStart _))
         {
-            RegisterType value = RegisterType.Read;
+            RegisterAccess value = RegisterAccess.Read;
             while (parser.TryConsume(out Scalar scalar))
             {
-                value |= (RegisterType)Enum.Parse(typeof(RegisterType), scalar.Value);
+                value |= (RegisterAccess)Enum.Parse(typeof(RegisterAccess), scalar.Value);
             }
             parser.Consume<SequenceEnd>();
             return value;
@@ -375,7 +375,7 @@ class RegisterTypeConverter : IYamlTypeConverter
         else
         {
             var scalar = parser.Consume<Scalar>();
-            return (RegisterType)Enum.Parse(typeof(RegisterType), scalar.Value);
+            return (RegisterAccess)Enum.Parse(typeof(RegisterAccess), scalar.Value);
         }
     }
 

--- a/schema/common.yml
+++ b/schema/common.yml
@@ -3,61 +3,61 @@ registers:
   WhoAmI:
     description: Specifies the identity class of the device.
     address: 0
-    registerType: Read
-    payloadType: U16
+    access: Read
+    type: U16
     interfaceType: int
   HardwareVersionHigh:
     description: Specifies the major hardware version of the device.
     address: 1
-    registerType: Read
-    payloadType: U8
+    access: Read
+    type: U8
   HardwareVersionLow:
     description: Specifies the minor hardware version of the device.
     address: 2
-    registerType: Read
-    payloadType: U8
+    access: Read
+    type: U8
   AssemblyVersion:
     description: Specifies the version of the assembled components in the device.
     address: 3
-    registerType: Read
-    payloadType: U8
+    access: Read
+    type: U8
   CoreVersionHigh:
     description: Specifies the major version of the Harp core implemented by the device.
     address: 4
-    registerType: Read
-    payloadType: U8
+    access: Read
+    type: U8
   CoreVersionLow:
     description: Specifies the minor version of the Harp core implemented by the device.
     address: 5
-    registerType: Read
-    payloadType: U8
+    access: Read
+    type: U8
   FirmwareVersionHigh:
     description: Specifies the major version of the Harp core implemented by the device.
     address: 6
-    registerType: Read
-    payloadType: U8
+    access: Read
+    type: U8
   FirmwareVersionLow:
     description: Specifies the minor version of the Harp core implemented by the device.
     address: 7
-    registerType: Read
-    payloadType: U8
+    access: Read
+    type: U8
   TimestampSeconds:
     description: Stores the integral part of the system timestamp, in seconds.
     address: 8
-    registerType: [Read, Write, Event]
-    payloadType: U32
+    access: [Read, Write, Event]
+    type: U32
     volatile: yes
   TimestampMicros:
     description: Stores the fractional part of the system timestamp, in microseconds.
     address: 9
-    registerType: Read
-    payloadType: U16
+    access: Read
+    type: U16
     volatile: yes
   OperationControl:
     description: Stores the configuration mode of the device.
     address: 10
-    registerType: Write
-    payloadType: U8
+    access: Write
+    type: U8
     payloadSpec:
       OperationMode:
         description: Specifies the operation mode of the device.
@@ -86,8 +86,8 @@ registers:
   Reset:
     description: Resets the device and saves non-volatile registers.
     address: 11
-    registerType: Write
-    payloadType: U8
+    access: Write
+    type: U8
     payloadSpec:
       ResetFromDefault:
         description: If this flag is enabled, the device resets and boots with all registers set to default values.
@@ -116,19 +116,19 @@ registers:
   DeviceName:
     description: Stores the user-specified device name.
     address: 12
-    registerType: Write
-    payloadType: U8
-    payloadLength: 25
+    access: Write
+    type: U8
+    length: 25
   SerialNumber:
     description: Specifies the unique serial number of the device.
     address: 13
-    registerType: Write
-    payloadType: U16
+    access: Write
+    type: U16
   ClockConfiguration:
     description: Specifies the configuration for the device synchronization clock.
     address: 14
-    registerType: Write
-    payloadType: U8
+    access: Write
+    type: U8
     payloadSpec:
       ClockRepeater:
         description: If this flag is enabled, specifies the device will repeat the clock synchronization signal to the clock output connector, if available.

--- a/schema/common.yml
+++ b/schema/common.yml
@@ -1,0 +1,171 @@
+# yaml-language-server: $schema=registers.json
+registers:
+  WhoAmI:
+    description: Specifies the identity class of the device.
+    address: 0
+    registerType: Read
+    payloadType: U16
+    interfaceType: int
+  HardwareVersionHigh:
+    description: Specifies the major hardware version of the device.
+    address: 1
+    registerType: Read
+    payloadType: U8
+  HardwareVersionLow:
+    description: Specifies the minor hardware version of the device.
+    address: 2
+    registerType: Read
+    payloadType: U8
+  AssemblyVersion:
+    description: Specifies the version of the assembled components in the device.
+    address: 3
+    registerType: Read
+    payloadType: U8
+  CoreVersionHigh:
+    description: Specifies the major version of the Harp core implemented by the device.
+    address: 4
+    registerType: Read
+    payloadType: U8
+  CoreVersionLow:
+    description: Specifies the minor version of the Harp core implemented by the device.
+    address: 5
+    registerType: Read
+    payloadType: U8
+  FirmwareVersionHigh:
+    description: Specifies the major version of the Harp core implemented by the device.
+    address: 6
+    registerType: Read
+    payloadType: U8
+  FirmwareVersionLow:
+    description: Specifies the minor version of the Harp core implemented by the device.
+    address: 7
+    registerType: Read
+    payloadType: U8
+  TimestampSeconds:
+    description: Stores the integral part of the system timestamp, in seconds.
+    address: 8
+    registerType: [Read, Write, Event]
+    payloadType: U32
+  TimestampMicros:
+    description: Stores the fractional part of the system timestamp, in microseconds.
+    address: 9
+    registerType: Read
+    payloadType: U16
+  OperationControl:
+    description: Stores the configuration mode of the device.
+    address: 10
+    registerType: Write
+    payloadType: U8
+    payloadSpec:
+      OperationMode:
+        description: Specifies the operation mode of the device.
+        maskType: OperationMode
+        mask: 0x3
+      DumpRegisters:
+        description: Specifies whether the device should report the content of all registers on initialization.
+        interfaceType: bool
+        mask: 0x8
+      MuteReplies:
+        description: Specifies whether the replies to all commands will be muted, i.e. not sent by the device.
+        interfaceType: bool
+        mask: 0x10
+      VisualIndicators:
+        description: Specifies the state of all visual indicators on the device.
+        maskType: LedState
+        mask: 0x20
+      OperationLed:
+        description: Specifies whether the device state LED should report the operation mode of the device.
+        maskType: LedState
+        mask: 0x40
+      Heartbeat:
+        description: Specifies whether the device should report the content of the seconds register each second.
+        maskType: EnableFlag
+        mask: 0x80
+  Reset:
+    description: Resets the device and saves non-volatile registers.
+    address: 11
+    registerType: Write
+    payloadType: U8
+    payloadSpec:
+      ResetFromDefault:
+        description: If this flag is enabled, the device resets and boots with all registers set to default values.
+        maskType: EnableFlag
+        mask: 0x1
+      ResetFromEeprom:
+        description: If this flag is enabled, the device resets and boots with all registers set to non-volatile values stored in EEPROM.
+        maskType: EnableFlag
+        mask: 0x2
+      SaveRegisters:
+        description: If this flag is enabled, the device saves all non-volatile registers to the internal EEPROM and reboots.
+        maskType: EnableFlag
+        mask: 0x4
+      ResetName:
+        description: If this flag is enabled, the device boots with the default name.
+        maskType: EnableFlag
+        mask: 0x8
+      BootFromDefault:
+        description: If this flag is enabled, specifies that the device has booted from default values.
+        maskType: EnableFlag
+        mask: 0x40
+      BootFromEeprom:
+        description: If this flag is enabled, specifies that the device has booted from non-volatile values stored in EEPROM.
+        maskType: EnableFlag
+        mask: 0x80
+  DeviceName:
+    description: Stores the user-specified device name.
+    address: 12
+    registerType: Write
+    payloadType: U8
+    payloadLength: 25
+  SerialNumber:
+    description: Specifies the unique serial number of the device.
+    address: 13
+    registerType: Write
+    payloadType: U16
+  ClockConfiguration:
+    description: Specifies the configuration for the device synchronization clock.
+    address: 14
+    registerType: Write
+    payloadType: U8
+    payloadSpec:
+      ClockRepeater:
+        description: If this flag is enabled, specifies the device will repeat the clock synchronization signal to the clock output connector, if available.
+        maskType: EnableFlag
+        mask: 0x1
+      ClockGenerator:
+        description: If this flag is enabled, the device resets and generates the clock synchronization signal on the clock output connector, if available.
+        maskType: EnableFlag
+        mask: 0x2
+      RepeaterCapability:
+        description: If this flag is enabled, the device has the capability to repeat the clock synchronization signal to the clock output connector.
+        maskType: EnableFlag
+        mask: 0x8
+      GeneratorCapability:
+        description: If this flag is enabled, the device has the capability to generate the clock synchronization signal to the clock output connector.
+        maskType: EnableFlag
+        mask: 0x10
+      ClockUnlock:
+        description: If this flag is enabled, the device will unlock the timestamp register counter and will accept commands to set new timestamp values.
+        maskType: EnableFlag
+        mask: 0x40
+      ClockLock:
+        description: If this flag is enabled, the device will lock the timestamp register counter and will not accept commands to set new timestamp values.
+        maskType: EnableFlag
+        mask: 0x80
+groupMasks:
+  OperationMode:
+    description: Specifies the operation mode of the device.
+    values:
+      Standby: {0, description: Disable all event reporting on the device.}
+      Active: {1, description: Event detection is enabled. Only enabled events are reported by the device.}
+      Speed: {3, description: The device enters speed mode.}
+  EnableFlag:
+    description: Specifies whether a specific register flag is enabled or disabled.
+    values:
+      Disabled: {0, description: Specifies that the flag is disabled.}
+      Enabled: {1, description: Specifies that the flag is enabled.}
+  LedState:
+    description: Specifies the state of an LED on the device.
+    values:
+      Off: {0, description: Specifies that the LED is off.}
+      On: {1, description: Specifies that the LED is on.}

--- a/schema/common.yml
+++ b/schema/common.yml
@@ -46,11 +46,13 @@ registers:
     address: 8
     registerType: [Read, Write, Event]
     payloadType: U32
+    volatile: yes
   TimestampMicros:
     description: Stores the fractional part of the system timestamp, in microseconds.
     address: 9
     registerType: Read
     payloadType: U16
+    volatile: yes
   OperationControl:
     description: Stores the configuration mode of the device.
     address: 10

--- a/schema/device.json
+++ b/schema/device.json
@@ -2,199 +2,39 @@
     "$schema": "https://json-schema.org/draft-07/schema",
     "$id": "https://harp-tech.org/2023-01/device",
     "type": "object",
-    "properties": {
-        "device": {
-            "description": "Specifies the name of the device.",
-            "type": "string"
-        },
-        "whoAmI": {
-            "description": "Specifies the unique identifier for this device type.",
-            "type": "integer"
-        },
-        "firmwareVersion": {
-            "description": "Specifies the semantic version of the device firmware.",
-            "type": "string"
-        },
-        "hardwareTargets": {
-            "description": "Specifies the semantic version of the device hardware.",
-            "type": "string"
-        },
-        "architecture": {
-            "description": "Architecture of the microcontroller.",
-            "type": "string"
-        },
-        "registers": {
-            "type": "object",
-            "description": "Specifies the collection of registers implementing the device function.",
-            "additionalProperties": { "$ref": "#/definitions/register" }
-        },
-        "bitMasks": {
-            "type": "object",
-            "description": "Specifies the collection of masks available to be used with the different registers.",
-            "additionalProperties": { "$ref": "#/definitions/bitMask" }
-        },
-        "groupMasks": {
-            "type": "object",
-            "description": "Specifies the collection of group masks available to be used with the different registers.",
-            "additionalProperties": { "$ref": "#/definitions/groupMask" }
-        }
-    },
-    "required": ["device", "whoAmI", "firmwareVersion", "hardwareTargets", "registers"],
-    "definitions": {
-        "payloadType": {
-            "description": "Specifies the type of the register payload.",
-            "type": "string",
-            "enum": ["U8", "S8", "U16", "S16", "U32", "S32", "U64", "S64", "Float"]
-        },
-        "registerType": {
-            "type": "string",
-            "enum": ["Read", "Write", "Event"]
-        },
-        "maskValue": {
-            "oneOf": [
-                { "type": "integer" },
-                {
-                    "type": "object",
-                    "properties": {
-                        "description": {
-                            "description": "Specifies a summary description of the mask value function.",
-                            "type": "string"
-                        }
-                    },
-                    "additionalProperties": false
-                }
-            ]
-        },
-        "bitMask": {
-            "description": "Specifies a bit mask used for reading or writing specific registers.",
-            "type": "object",
+    "allOf": [
+        {
             "properties": {
-                "description": {
-                    "description": "Specifies a summary description of the bit mask function.",
+                "device": {
+                    "description": "Specifies the name of the device.",
                     "type": "string"
                 },
-                "bits": {
-                    "type": "object",
-                    "additionalProperties": { "$ref": "#/definitions/maskValue" }
-                }
-            },
-            "required": ["bits"]
-        },
-        "groupMask": {
-            "description": "Specifies a group mask used for reading or writing specific registers.",
-            "type": "object",
-            "properties": {
-                "description": {
-                    "description": "Specifies a summary description of the group mask function.",
-                    "type": "string"
-                },
-                "values": {
-                    "type": "object",
-                    "additionalProperties": { "$ref": "#/definitions/maskValue" }
-                }
-            },
-            "required": ["values"]
-        },
-        "maskType": {
-            "description": "Specifies the name of the bit mask or group mask used to represent the payload value.",
-            "type": "string"
-        },
-        "interfaceType": {
-            "description": "Specifies the name of the type used to represent the payload value in the high-level interface.",
-            "type": "string"
-        },
-        "converter": {
-            "description": "Specifies a custom converter method used to parse or format the payload value in the high-level interface.",
-            "type": "string"
-        },
-        "minValue": {
-            "description": "Specifies the minimum allowable value for the payload or payload member.",
-            "type": "number"
-        },
-        "maxValue": {
-            "description": "Specifies the maximum allowable value for the payload or payload member.",
-            "type": "number"
-        },
-        "defaultValue": {
-            "description": "Specifies the default value for the payload or payload member.",
-            "type": "number"
-        },
-        "payloadMember": {
-            "type": "object",
-            "properties": {
-                "description": {
-                    "description": "Specifies a summary description of the payload member.",
-                    "type": "string"
-                },
-                "mask": {
-                    "description": "Specifies the mask used to read and write this payload member.",
+                "whoAmI": {
+                    "description": "Specifies the unique identifier for this device type.",
                     "type": "integer"
                 },
-                "offset": {
-                    "description": "Specifies the payload array offset where this payload member is stored.",
-                    "type": "integer"
-                },
-                "maskType": { "$ref": "#/definitions/maskType" },
-                "interfaceType": { "$ref": "#/definitions/interfaceType" },
-                "converter": { "$ref": "#/definitions/converter" },
-                "minValue": { "$ref": "#/definitions/minValue" },
-                "maxValue": { "$ref": "#/definitions/maxValue" },
-                "defaultValue": { "$ref": "#/definitions/defaultValue" }
-            }
-        },
-        "register": {
-            "type": "object",
-            "properties": {
-                "description": {
-                    "description": "Specifies a summary description of the register function.",
+                "firmwareVersion": {
+                    "description": "Specifies the semantic version of the device firmware.",
                     "type": "string"
                 },
-                "address": {
-                    "description": "Specifies the unique 8-bit address of the register.",
-                    "type": "integer",
-                    "minimum": 32,
-                    "maximum": 255
+                "hardwareTargets": {
+                    "description": "Specifies the semantic version of the device hardware.",
+                    "type": "string"
                 },
-                "registerType": {
-                    "description": "Specifies the expected use of the register.",
-                    "oneOf": [
-                        { "$ref": "#/definitions/registerType" },
-                        {
-                            "type": "array",
-                            "items": { "$ref": "#/definitions/registerType" },
-                            "uniqueItems": true,
-                            "minItems": 1,
-                            "maxItems": 3
+                "architecture": {
+                    "description": "Architecture of the microcontroller.",
+                    "type": "string"
+                },
+                "registers": {
+                    "additionalProperties": {
+                        "properties": {
+                            "address": { "minimum": 32 }
                         }
-                    ]
-                },
-                "payloadType": { "$ref": "#/definitions/payloadType" },
-                "payloadLength": {
-                    "description": "Specifies the length of the register payload.",
-                    "type": "integer",
-                    "minimum": 1
-                },
-                "payloadSpec": {
-                    "type": "object",
-                    "additionalProperties": { "$ref": "#/definitions/payloadMember" }
-                },
-                "maskType": { "$ref": "#/definitions/maskType" },
-                "interfaceType": { "$ref": "#/definitions/interfaceType" },
-                "converter": { "$ref": "#/definitions/converter" },
-                "minValue": { "$ref": "#/definitions/minValue" },
-                "maxValue": { "$ref": "#/definitions/maxValue" },
-                "defaultValue": { "$ref": "#/definitions/defaultValue" },
-                "visibility": {
-                    "description": "Specifies whether the register function is exposed in the high-level interface.",
-                    "type": "string",
-                    "enum": ["public", "private"]
-                },
-                "group": {
-                    "description": "Specifies an optional group name used to expose the register function in the high-level interface.",
-                    "type": "string"
+                    }
                 }
             },
-            "required": ["address", "registerType", "payloadType"]
-        }
-    }
+            "required": ["device", "whoAmI", "firmwareVersion", "hardwareTargets"]
+        },
+        { "$ref": "registers.json" }
+    ]
 }

--- a/schema/example.yml
+++ b/schema/example.yml
@@ -7,60 +7,60 @@ architecture: "atmega"
 registers:
   Cam0Event:
     address: 32
-    payloadType: U8
-    registerType: Event
+    type: U8
+    access: Event
   Cam0TriggerFrequency:
     address: 33
-    registerType: Write
-    payloadType: U16
+    access: Write
+    type: U16
     maskType: DO
     description: Sets the trigger frequency for camera 0 between 1 and 1000.
   Cam0TriggerDuration:
     address: 34
-    registerType: Write
-    payloadType: U16
+    access: Write
+    type: U16
     description: Sets the duration of the trigger pulse (minimum is 100) for camera 0.
   StartAndStop:
     address: 35
-    registerType: Write
-    payloadType: U8
+    access: Write
+    type: U8
     description: Starts or stops the camera immediately.
   InState:
     address: 36
-    registerType: Event
-    payloadType: U8
+    access: Event
+    type: U8
     description: Contains the state of the input ports.
   Valve0Pulse:
     address: 37
-    registerType: Write
-    payloadType: U8
+    access: Write
+    type: U8
     description: Configures the valve 0 open time in milliseconds.
   OutSet:
     address: 38
-    registerType: Write
-    payloadType: U8
+    access: Write
+    type: U8
     description: Bitmask to set the available outputs.
   OutClear:
     address: 39
-    registerType: Write
-    payloadType: U8
+    access: Write
+    type: U8
     description: Bitmask to clear the available outputs.
   OutToggle:
     address: 40
-    registerType: Write
-    payloadType: U8
+    access: Write
+    type: U8
     description: Bitmask to toggle the available outputs.
   OutWrite:
     address: 41
-    registerType: Write
-    payloadType: U8
+    access: Write
+    type: U8
     maskType: DO
     description: Bitmask to write the available outputs.
   AnalogIn:
     address: 42
-    registerType: Event
-    payloadType: U16
-    payloadLength: 2
+    access: Event
+    type: U16
+    length: 2
     payloadSpec:
       ADC:
         description: The value of the board ADC.

--- a/schema/registers.json
+++ b/schema/registers.json
@@ -147,6 +147,11 @@
                         }
                     ]
                 },
+                "volatile": {
+                    "description": "Specifies whether register values can be saved in non-volatile memory.",
+                    "type": "string",
+                    "enum": ["no", "yes"]
+                },
                 "payloadType": { "$ref": "#/definitions/payloadType" },
                 "payloadLength": {
                     "description": "Specifies the length of the register payload.",

--- a/schema/registers.json
+++ b/schema/registers.json
@@ -125,14 +125,16 @@
         "register": {
             "type": "object",
             "properties": {
-                "description": {
-                    "description": "Specifies a summary description of the register function.",
-                    "type": "string"
-                },
                 "address": {
                     "description": "Specifies the unique 8-bit address of the register.",
                     "type": "integer",
                     "maximum": 255
+                },
+                "type": { "$ref": "#/definitions/type" },
+                "length": {
+                    "description": "Specifies the length of the register payload.",
+                    "type": "integer",
+                    "minimum": 1
                 },
                 "access": {
                     "description": "Specifies the expected use of the register.",
@@ -147,32 +149,30 @@
                         }
                     ]
                 },
+                "description": {
+                    "description": "Specifies a summary description of the register function.",
+                    "type": "string"
+                },
+                "minValue": { "$ref": "#/definitions/minValue" },
+                "maxValue": { "$ref": "#/definitions/maxValue" },
+                "defaultValue": { "$ref": "#/definitions/defaultValue" },
+                "maskType": { "$ref": "#/definitions/maskType" },
+                "visibility": {
+                    "description": "Specifies whether the register function is exposed in the high-level interface.",
+                    "type": "string",
+                    "enum": ["public", "private"]
+                },
                 "volatile": {
                     "description": "Specifies whether register values can be saved in non-volatile memory.",
                     "type": "string",
                     "enum": ["no", "yes"]
                 },
-                "type": { "$ref": "#/definitions/type" },
-                "length": {
-                    "description": "Specifies the length of the register payload.",
-                    "type": "integer",
-                    "minimum": 1
-                },
                 "payloadSpec": {
                     "type": "object",
                     "additionalProperties": { "$ref": "#/definitions/payloadMember" }
                 },
-                "maskType": { "$ref": "#/definitions/maskType" },
                 "interfaceType": { "$ref": "#/definitions/interfaceType" },
-                "converter": { "$ref": "#/definitions/converter" },
-                "minValue": { "$ref": "#/definitions/minValue" },
-                "maxValue": { "$ref": "#/definitions/maxValue" },
-                "defaultValue": { "$ref": "#/definitions/defaultValue" },
-                "visibility": {
-                    "description": "Specifies whether the register function is exposed in the high-level interface.",
-                    "type": "string",
-                    "enum": ["public", "private"]
-                }
+                "converter": { "$ref": "#/definitions/converter" }
             },
             "required": ["address", "access", "type"]
         }

--- a/schema/registers.json
+++ b/schema/registers.json
@@ -1,0 +1,179 @@
+{
+    "$schema": "https://json-schema.org/draft-07/schema",
+    "$id": "https://harp-tech.org/2023-03/registers",
+    "type": "object",
+    "properties": {
+        "registers": {
+            "type": "object",
+            "description": "Specifies the collection of registers implementing the device function.",
+            "additionalProperties": { "$ref": "#/definitions/register" }
+        },
+        "bitMasks": {
+            "type": "object",
+            "description": "Specifies the collection of masks available to be used with the different registers.",
+            "additionalProperties": { "$ref": "#/definitions/bitMask" }
+        },
+        "groupMasks": {
+            "type": "object",
+            "description": "Specifies the collection of group masks available to be used with the different registers.",
+            "additionalProperties": { "$ref": "#/definitions/groupMask" }
+        }
+    },
+    "required": ["registers"],
+    "definitions": {
+        "payloadType": {
+            "description": "Specifies the type of the register payload.",
+            "type": "string",
+            "enum": ["U8", "S8", "U16", "S16", "U32", "S32", "U64", "S64", "Float"]
+        },
+        "registerType": {
+            "type": "string",
+            "enum": ["Read", "Write", "Event"]
+        },
+        "maskValue": {
+            "oneOf": [
+                { "type": "integer" },
+                {
+                    "type": "object",
+                    "properties": {
+                        "description": {
+                            "description": "Specifies a summary description of the mask value function.",
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false
+                }
+            ]
+        },
+        "bitMask": {
+            "description": "Specifies a bit mask used for reading or writing specific registers.",
+            "type": "object",
+            "properties": {
+                "description": {
+                    "description": "Specifies a summary description of the bit mask function.",
+                    "type": "string"
+                },
+                "bits": {
+                    "type": "object",
+                    "additionalProperties": { "$ref": "#/definitions/maskValue" }
+                }
+            },
+            "required": ["bits"]
+        },
+        "groupMask": {
+            "description": "Specifies a group mask used for reading or writing specific registers.",
+            "type": "object",
+            "properties": {
+                "description": {
+                    "description": "Specifies a summary description of the group mask function.",
+                    "type": "string"
+                },
+                "values": {
+                    "type": "object",
+                    "additionalProperties": { "$ref": "#/definitions/maskValue" }
+                }
+            },
+            "required": ["values"]
+        },
+        "maskType": {
+            "description": "Specifies the name of the bit mask or group mask used to represent the payload value.",
+            "type": "string"
+        },
+        "interfaceType": {
+            "description": "Specifies the name of the type used to represent the payload value in the high-level interface.",
+            "type": "string"
+        },
+        "converter": {
+            "description": "Specifies a custom converter method used to parse or format the payload value in the high-level interface.",
+            "type": "string"
+        },
+        "minValue": {
+            "description": "Specifies the minimum allowable value for the payload or payload member.",
+            "type": "number"
+        },
+        "maxValue": {
+            "description": "Specifies the maximum allowable value for the payload or payload member.",
+            "type": "number"
+        },
+        "defaultValue": {
+            "description": "Specifies the default value for the payload or payload member.",
+            "type": "number"
+        },
+        "payloadMember": {
+            "type": "object",
+            "properties": {
+                "description": {
+                    "description": "Specifies a summary description of the payload member.",
+                    "type": "string"
+                },
+                "mask": {
+                    "description": "Specifies the mask used to read and write this payload member.",
+                    "type": "integer"
+                },
+                "offset": {
+                    "description": "Specifies the payload array offset where this payload member is stored.",
+                    "type": "integer"
+                },
+                "maskType": { "$ref": "#/definitions/maskType" },
+                "interfaceType": { "$ref": "#/definitions/interfaceType" },
+                "converter": { "$ref": "#/definitions/converter" },
+                "minValue": { "$ref": "#/definitions/minValue" },
+                "maxValue": { "$ref": "#/definitions/maxValue" },
+                "defaultValue": { "$ref": "#/definitions/defaultValue" }
+            }
+        },
+        "register": {
+            "type": "object",
+            "properties": {
+                "description": {
+                    "description": "Specifies a summary description of the register function.",
+                    "type": "string"
+                },
+                "address": {
+                    "description": "Specifies the unique 8-bit address of the register.",
+                    "type": "integer",
+                    "maximum": 255
+                },
+                "registerType": {
+                    "description": "Specifies the expected use of the register.",
+                    "oneOf": [
+                        { "$ref": "#/definitions/registerType" },
+                        {
+                            "type": "array",
+                            "items": { "$ref": "#/definitions/registerType" },
+                            "uniqueItems": true,
+                            "minItems": 1,
+                            "maxItems": 3
+                        }
+                    ]
+                },
+                "payloadType": { "$ref": "#/definitions/payloadType" },
+                "payloadLength": {
+                    "description": "Specifies the length of the register payload.",
+                    "type": "integer",
+                    "minimum": 1
+                },
+                "payloadSpec": {
+                    "type": "object",
+                    "additionalProperties": { "$ref": "#/definitions/payloadMember" }
+                },
+                "maskType": { "$ref": "#/definitions/maskType" },
+                "interfaceType": { "$ref": "#/definitions/interfaceType" },
+                "converter": { "$ref": "#/definitions/converter" },
+                "minValue": { "$ref": "#/definitions/minValue" },
+                "maxValue": { "$ref": "#/definitions/maxValue" },
+                "defaultValue": { "$ref": "#/definitions/defaultValue" },
+                "visibility": {
+                    "description": "Specifies whether the register function is exposed in the high-level interface.",
+                    "type": "string",
+                    "enum": ["public", "private"]
+                },
+                "group": {
+                    "description": "Specifies an optional group name used to expose the register function in the high-level interface.",
+                    "type": "string"
+                }
+            },
+            "required": ["address", "registerType", "payloadType"]
+        }
+    }
+}

--- a/schema/registers.json
+++ b/schema/registers.json
@@ -172,10 +172,6 @@
                     "description": "Specifies whether the register function is exposed in the high-level interface.",
                     "type": "string",
                     "enum": ["public", "private"]
-                },
-                "group": {
-                    "description": "Specifies an optional group name used to expose the register function in the high-level interface.",
-                    "type": "string"
                 }
             },
             "required": ["address", "registerType", "payloadType"]

--- a/schema/registers.json
+++ b/schema/registers.json
@@ -21,12 +21,12 @@
     },
     "required": ["registers"],
     "definitions": {
-        "payloadType": {
+        "type": {
             "description": "Specifies the type of the register payload.",
             "type": "string",
             "enum": ["U8", "S8", "U16", "S16", "U32", "S32", "U64", "S64", "Float"]
         },
-        "registerType": {
+        "access": {
             "type": "string",
             "enum": ["Read", "Write", "Event"]
         },
@@ -134,13 +134,13 @@
                     "type": "integer",
                     "maximum": 255
                 },
-                "registerType": {
+                "access": {
                     "description": "Specifies the expected use of the register.",
                     "oneOf": [
-                        { "$ref": "#/definitions/registerType" },
+                        { "$ref": "#/definitions/access" },
                         {
                             "type": "array",
-                            "items": { "$ref": "#/definitions/registerType" },
+                            "items": { "$ref": "#/definitions/access" },
                             "uniqueItems": true,
                             "minItems": 1,
                             "maxItems": 3
@@ -152,8 +152,8 @@
                     "type": "string",
                     "enum": ["no", "yes"]
                 },
-                "payloadType": { "$ref": "#/definitions/payloadType" },
-                "payloadLength": {
+                "type": { "$ref": "#/definitions/type" },
+                "length": {
                     "description": "Specifies the length of the register payload.",
                     "type": "integer",
                     "minimum": 1
@@ -174,7 +174,7 @@
                     "enum": ["public", "private"]
                 }
             },
-            "required": ["address", "registerType", "payloadType"]
+            "required": ["address", "access", "type"]
         }
     }
 }


### PR DESCRIPTION
This PR splits the main schema into device and register interface schemas. The reason for the change is two-fold:

1. Allow expressing different constraints for common and application registers (e.g. min address is 32 for application registers)
2. Allow additional high-level / application-specific interfaces to be generated on top of existing device schemas

Automatic generation can take care of merging together multiple metadata files when generating the final interface.