### PR TITLE
Add missing operators for named registers

### DIFF
--- a/interface/Device.tt
+++ b/interface/Device.tt
@@ -28,6 +28,7 @@ foreach (var ns in Host.StandardImports)
     WriteLine("using " + ns + ";");
 }
 #>
+using System.Collections.Generic;
 using System.ComponentModel;
 using System.Reactive.Linq;
 using System.Xml.Serialization;
@@ -49,6 +50,43 @@ namespace <#= namespaceName #>
         public Device() : base(whoAmI: <#= deviceMetadata.WhoAmI #>) { }
 
         string INamedElement.Name => nameof(<#= deviceName #>);
+
+        /// <summary>
+        /// Gets a read-only mapping from address to register name.
+        /// </summary>
+        public static IReadOnlyDictionary<int, string> RegisterMap { get; } = new Dictionary<int, string>
+        {
+<#
+int registerIndex = 0;
+foreach (var register in publicRegisters)
+{
+#>
+            { <#= register.Value.Address #>, "<#= register.Key #>" }<#= ++registerIndex < publicRegisters.Count ? "," : string.Empty #>
+<#
+}
+#>
+        };
+    }
+
+    /// <summary>
+    /// Represents an operator that groups the sequence of <see cref="<#= deviceName #>"/>" messages by register name.
+    /// </summary>
+    [Description("Groups the sequence of <#= deviceName #> messages by register name.")]
+    public partial class GroupByRegister : Combinator<HarpMessage, IGroupedObservable<string, HarpMessage>>
+    {
+        /// <summary>
+        /// Groups an observable sequence of <see cref="<#= deviceName #>"/> messages
+        /// by register name.
+        /// </summary>
+        /// <param name="source">The sequence of Harp device messages.</param>
+        /// <returns>
+        /// A sequence of observable groups, each of which corresponds to a unique
+        /// <see cref="<#= deviceName #>"/> register.
+        /// </returns>
+        public override IObservable<IGroupedObservable<string, HarpMessage>> Process(IObservable<HarpMessage> source)
+        {
+            return source.GroupBy(message => Device.RegisterMap[message.Address]);
+        }
     }
 <#
 if (publicRegisters.Count > 0)

--- a/interface/Device.tt
+++ b/interface/Device.tt
@@ -94,6 +94,30 @@ if (publicRegisters.Count > 0)
 #>
 
     /// <summary>
+    /// Represents an operator that filters register-specific messages
+    /// reported by the <see cref="<#= deviceName #>"/> device.
+    /// </summary>
+<#
+foreach (var register in publicRegisters)
+{
+#>
+    [XmlInclude(typeof(Bonsai.Expressions.TypeMapping<<#= register.Key #>>))]
+<#
+}
+#>
+    [Description("Filters register-specific messages reported by the <#= deviceName #> device.")]
+    public class FilterMessage : FilterMessageBuilder
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="FilterMessage"/> class.
+        /// </summary>
+        public FilterMessage()
+        {
+            Register = new Bonsai.Expressions.TypeMapping<<#= publicRegisters.First().Key #>>();
+        }
+    }
+
+    /// <summary>
     /// Represents an operator which filters and selects specific messages
     /// reported by the <#= deviceName #> device.
     /// </summary>


### PR DESCRIPTION
This PR adds the missing `FilterMessage` and `GroupByRegister` operators that round up the core message manipulation functionality of generated interfaces.

* `FilterMessage` allows filtering raw messages directly by register name, instead of register address.
* `GroupByRegister` demultiplexes a stream of Harp messages into separate groups indexed by register name.