### PR TITLE
Remove architecture property from device schema

### DIFF
--- a/schema/device.json
+++ b/schema/device.json
@@ -21,10 +21,6 @@
                     "description": "Specifies the semantic version of the device hardware.",
                     "type": "string"
                 },
-                "architecture": {
-                    "description": "Architecture of the microcontroller.",
-                    "type": "string"
-                },
                 "registers": {
                     "additionalProperties": {
                         "properties": {


### PR DESCRIPTION
This PR removes the property specifying the micro-controller architecture from the first draft of the abstract device schema.

Since alternative ways of specifying the micro-controller implementation architecture for automatic firmware generation are still being considered, we don't want to commit too soon to this design choice.