### PR TITLE
Align naming of async device class with core API

### DIFF
--- a/interface/AsyncDevice.tt
+++ b/interface/AsyncDevice.tt
@@ -12,7 +12,6 @@
 var deviceMetadata = TemplateHelper.ReadDeviceMetadata(MetadataPath);
 var publicRegisters = deviceMetadata.Registers.Where(register => register.Value.Visibility == RegisterVisibility.Public).ToList();
 var deviceName = deviceMetadata.Device;
-var deviceClassName = deviceName + "Device";
 #>
 using Bonsai.Harp;
 using System.Threading.Tasks;
@@ -22,15 +21,15 @@ namespace <#= Namespace #>
     /// <summary>
     /// Represents an asynchronous API to configure and interface with <#= deviceName #> devices.
     /// </summary>
-    public partial class <#= deviceClassName #> : AsyncDevice
+    public partial class AsyncDevice : Bonsai.Harp.AsyncDevice
     {
-        private <#= deviceClassName #>(string portName)
+        private AsyncDevice(string portName)
             : base(portName)
         {
         }
 
         /// <summary>
-        /// Asynchronously initializes a new instance of the <see cref="<#= deviceClassName #>"/>
+        /// Asynchronously initializes a new instance of the <see cref="AsyncDevice"/>
         /// class on the specified port.
         /// </summary>
         /// <param name="portName">
@@ -40,9 +39,9 @@ namespace <#= Namespace #>
         /// A task that represents the asynchronous initialization operation. The value of
         /// the <see cref="Task{TResult}.Result"/> parameter contains the device object.
         /// </returns>
-        public static async Task<<#= deviceClassName #>> CreateAsync(string portName)
+        public static async Task<AsyncDevice> CreateAsync(string portName)
         {
-            var device = new <#= deviceClassName #>(portName);
+            var device = new AsyncDevice(portName);
             var whoAmI = await device.ReadUInt16Async(DeviceRegisters.WhoAmI);
             if (whoAmI != <#= deviceMetadata.WhoAmI #>)
             {

--- a/interface/AsyncDevice.tt
+++ b/interface/AsyncDevice.tt
@@ -18,26 +18,20 @@ using System.Threading.Tasks;
 
 namespace <#= Namespace #>
 {
-    /// <summary>
-    /// Represents an asynchronous API to configure and interface with <#= deviceName #> devices.
-    /// </summary>
-    public partial class AsyncDevice : Bonsai.Harp.AsyncDevice
+    /// <inheritdoc/>
+    public partial class Device
     {
-        private AsyncDevice(string portName)
-            : base(portName)
-        {
-        }
-
         /// <summary>
-        /// Asynchronously initializes a new instance of the <see cref="AsyncDevice"/>
-        /// class on the specified port.
+        /// Initializes a new instance of the asynchronous API to configure and interface
+        /// with <#= deviceName #> devices on the specified serial port.
         /// </summary>
         /// <param name="portName">
         /// The name of the serial port used to communicate with the Harp device.
         /// </param>
         /// <returns>
         /// A task that represents the asynchronous initialization operation. The value of
-        /// the <see cref="Task{TResult}.Result"/> parameter contains the device object.
+        /// the <see cref="Task{TResult}.Result"/> parameter contains a new instance of
+        /// the <see cref="AsyncDevice"/> class.
         /// </returns>
         public static async Task<AsyncDevice> CreateAsync(string portName)
         {
@@ -52,6 +46,17 @@ namespace <#= Namespace #>
             }
 
             return device;
+        }
+    }
+
+    /// <summary>
+    /// Represents an asynchronous API to configure and interface with <#= deviceName #> devices.
+    /// </summary>
+    public partial class AsyncDevice : Bonsai.Harp.AsyncDevice
+    {
+        internal AsyncDevice(string portName)
+            : base(portName)
+        {
         }
 <#
 foreach (var registerMetadata in publicRegisters)


### PR DESCRIPTION
This PR aligns the naming of the async device class with the core Harp API for consistency with the remaining automatically generated interfaces. The async API is now called `AsyncDevice` in all device namespaces.

Although superficially this violates framework design guidelines for [Namespaces and Type Name Conflicts](https://learn.microsoft.com/en-us/dotnet/standard/design-guidelines/names-of-namespaces?redirectedfrom=MSDN#namespaces-and-type-name-conflicts), the usage in practice can be made quite readable:

```c#
using Bonsai.Harp;
using Behavior = Harp.Behavior;

namespace App
{
    static class Program
    {
        public static async void Main()
        {
            var device = await Behavior.Device.CreateAsync("COM1");
            var dev = await device.ReadFirmwareVersionAsync();
            var register = await device.ReadDigitalInputsAsync();
            var rawRegister = await device.CommandAsync(Behavior.DigitalInputs.FromPayload(MessageType.Read, 0));
        }
    }
}
```