### PR TITLE
Avoid duplicating payload type definitions

### DIFF
--- a/interface/Device.tt
+++ b/interface/Device.tt
@@ -585,11 +585,13 @@ foreach (var registerMetadata in writeRegisters)
 } // commandRegisters.Count > 0
 #>
 <#
+var payloadTypes = new HashSet<string>();
 foreach (var registerMetadata in deviceMetadata.Registers)
 {
     var register = registerMetadata.Value;
     if (register.PayloadSpec == null) continue;
     var interfaceType = TemplateHelper.GetInterfaceType(registerMetadata.Key, register);
+    if (!payloadTypes.Add(interfaceType)) continue;
 #>
 
     /// <summary>


### PR DESCRIPTION
This PR prevents redeclaration of payload type definitions with the same name. Re-use of payload type declarations are expected to use YAML anchors and references to avoid code generation errors.

```yaml
  OutputSet:
    address: 34
    type: U16
    access: Write
    description: Set the specified digital output lines
    payloadSpec: &outputSpec
      Port0:
        mask: 0x1
        interfaceType: bool
        description: Port0 value
    interfaceType: &outputSpecType OutputPayload
  OutputClear:
    address: 35
    type: U16
    access: Write
    description: Clear the specified digital output lines
    payloadSpec: *outputSpec
    interfaceType: *outputSpecType
```