### PR TITLE
Add support for YAML merge keys

### DIFF
--- a/interface/Device.tt
+++ b/interface/Device.tt
@@ -592,10 +592,11 @@ foreach (var registerMetadata in deviceMetadata.Registers)
     if (register.PayloadSpec == null) continue;
     var interfaceType = TemplateHelper.GetInterfaceType(registerMetadata.Key, register);
     if (!payloadTypes.Add(interfaceType)) continue;
+    var registerName = TemplateHelper.RemoveSuffix(interfaceType, "Payload");
 #>
 
     /// <summary>
-    /// Represents the payload of the <#= registerMetadata.Key #> register.
+    /// Represents the payload of the <#= registerName #> register.
     /// </summary>
     public struct <#= interfaceType #>
     {

--- a/interface/Interface.tt
+++ b/interface/Interface.tt
@@ -96,12 +96,13 @@ public static partial class TemplateHelper
     {
         using (var reader = new StreamReader(path))
         {
+            var parser = new MergingParser(new Parser(reader));
             var deserializer = new DeserializerBuilder()
                 .WithNamingConvention(CamelCaseNamingConvention.Instance)
                 .WithTypeConverter(RegisterAccessTypeConverter.Instance)
                 .WithTypeConverter(MaskValueTypeConverter.Instance)
                 .Build();
-            return deserializer.Deserialize<DeviceInfo>(reader);
+            return deserializer.Deserialize<DeviceInfo>(parser);
         }
     }
 

--- a/interface/Interface.tt
+++ b/interface/Interface.tt
@@ -307,6 +307,13 @@ public static partial class TemplateHelper
         }
         else return $" = {expression}";
     }
+
+    public static string RemoveSuffix(string value, string suffix)
+    {
+        return value.EndsWith(suffix)
+            ? value.Substring(0, value.Length - suffix.Length)
+            : value;
+    }
 }
 
 class MaskValueTypeConverter : IYamlTypeConverter


### PR DESCRIPTION
This PR adds support for YAML merge keys in the automatic source generator. While merge keys are technically outdated following [YAML 1.1](https://yaml.org/type/merge.html), they remain the best way to reduce repetition in large device specs.