### PR TITLE
Make volatile a boolean field

### DIFF
--- a/interface/Interface.tt
+++ b/interface/Interface.tt
@@ -45,6 +45,7 @@ public class RegisterInfo
     public int Length;
     public Dictionary<string, PayloadMemberInfo> PayloadSpec;
     public RegisterVisibility Visibility;
+    public bool Volatile;
     public string MaskType;
     public string InterfaceType;
     public string Converter;

--- a/schema/registers.json
+++ b/schema/registers.json
@@ -164,8 +164,7 @@
                 },
                 "volatile": {
                     "description": "Specifies whether register values can be saved in non-volatile memory.",
-                    "type": "string",
-                    "enum": ["no", "yes"]
+                    "type": "boolean"
                 },
                 "payloadSpec": {
                     "type": "object",


### PR DESCRIPTION
This PR updates the volatile property to use a `boolean` type. This will make both parsing and documentation of this field easier and more in-line with language built-in types.