### PR TITLE
Auto-generate converter method declarations

### DIFF
--- a/interface/Device.tt
+++ b/interface/Device.tt
@@ -190,11 +190,15 @@ foreach (var register in publicRegisters)
 foreach (var registerMetadata in publicRegisters)
 {
     var register = registerMetadata.Value;
+    var hasConverter = register.HasConverter;
+    var rawPayload = register.Converter == MemberConverter.RawPayload;
     var hasEvent = (register.Access & RegisterAccess.Event) != 0;
     var allowWrite = (register.Access & RegisterAccess.Write) != 0;
     var defaultMessageType = hasEvent ? "Event" : (allowWrite ? "Write" : "Read");
     var interfaceType = TemplateHelper.GetInterfaceType(registerMetadata.Key, register);
-    var parsePayloadSuffix = TemplateHelper.GetPayloadTypeSuffix(register.Type, register.Length);
+    var parsePayloadSuffix = rawPayload
+        ? string.Empty
+        : TemplateHelper.GetPayloadTypeSuffix(register.Type, register.Length);
     var parsePayloadSelector = $"message.GetPayload{parsePayloadSuffix}()";
     var parseConversion = TemplateHelper.GetParseConversion(register, parsePayloadSelector);
 
@@ -202,8 +206,9 @@ foreach (var registerMetadata in publicRegisters)
     var timestampedPayloadSelector = $"message.GetTimestampedPayload{parsePayloadSuffix}()";
     var timestampedParseConversion = TemplateHelper.GetParseConversion(register, payloadValueSelector);
 
-    var formatPayloadSuffix = TemplateHelper.GetPayloadTypeSuffix(register.Type);
+    var formatPayloadSuffix = rawPayload ? "Payload" : TemplateHelper.GetPayloadTypeSuffix(register.Type);
     var formatConversion = TemplateHelper.GetFormatConversion(register, "value");
+    if (rawPayload) formatConversion = $"PayloadType.{register.Type}, {formatConversion}";
     var summaryDescription = string.IsNullOrEmpty(register.Description)
         ? $"manipulates messages from register {registerMetadata.Key}"
         : $"{char.ToLower(register.Description[0])}{register.Description.Substring(1).TrimEnd('.')}";
@@ -235,8 +240,26 @@ foreach (var registerMetadata in publicRegisters)
     }
 #>
 <#
-    if (register.PayloadSpec != null && string.IsNullOrEmpty(register.Converter))
+    if (hasConverter)
     {
+#>
+
+        private static partial <#= interfaceType #> ParsePayload(<#= register.PayloadInterfaceType #> payload);
+<#
+    }
+    else if (register.PayloadSpec != null)
+    {
+        foreach (var member in register.PayloadSpec)
+        {
+            if (member.Value.HasConverter)
+            {
+                var memberType = TemplateHelper.GetInterfaceType(member.Value, register.Type);
+#>
+
+        private static partial <#= memberType #> ParsePayload<#= member.Key #>(<#= register.PayloadInterfaceType #> payload<#= member.Key #>);
+<#
+            }
+        }
 #>
 
         static <#= interfaceType #> ParsePayload(<#= register.PayloadInterfaceType #> payload)
@@ -246,6 +269,7 @@ foreach (var registerMetadata in publicRegisters)
         foreach (var member in register.PayloadSpec)
         {
             var memberConversion = TemplateHelper.GetPayloadMemberParser(
+                member.Key,
                 member.Value,
                 "payload",
                 register.Type);
@@ -259,8 +283,27 @@ foreach (var registerMetadata in publicRegisters)
 <#
     }
 
-    if (register.PayloadSpec != null && string.IsNullOrEmpty(register.Converter))
+    if (hasConverter)
     {
+#>
+
+        private static partial <#= register.PayloadInterfaceType #> FormatPayload(<#= interfaceType #> value);
+<#
+    }
+    else if (register.PayloadSpec != null)
+    {
+        foreach (var member in register.PayloadSpec)
+        {
+            if (member.Value.HasConverter)
+            {
+                var paramName = CamelCaseNamingConvention.Instance.Apply(member.Key);
+                var memberType = TemplateHelper.GetInterfaceType(member.Value, register.Type);
+#>
+
+        private static partial <#= register.PayloadInterfaceType #> FormatPayload<#= member.Key #>(<#= memberType #> <#= paramName #>);
+<#
+            }
+        }
 #>
 
         static <#= register.PayloadInterfaceType #> FormatPayload(<#= interfaceType #> value)
@@ -281,6 +324,7 @@ foreach (var registerMetadata in publicRegisters)
             var payloadIndex = member.Value.Offset.GetValueOrDefault(0);
             var memberIndexer = member.Value.Offset.HasValue ? $"[{member.Value.Offset}]" : string.Empty;
             var memberConversion = TemplateHelper.GetPayloadMemberFormatter(
+                member.Key,
                 member.Value,
                 $"value.{member.Key}",
                 register.Type,

--- a/interface/Interface.tt
+++ b/interface/Interface.tt
@@ -36,6 +36,13 @@ public enum RegisterVisibility
     Private
 }
 
+public enum MemberConverter
+{
+    None,
+    Payload,
+    RawPayload
+}
+
 public class RegisterInfo
 {
     public int Address;
@@ -48,12 +55,15 @@ public class RegisterInfo
     public bool Volatile;
     public string MaskType;
     public string InterfaceType;
-    public string Converter;
+    public MemberConverter Converter;
     public float? MinValue;
     public float? MaxValue;
     public float? DefaultValue;
 
-    public string PayloadInterfaceType => TemplateHelper.GetInterfaceType(Type, Length);
+    public bool HasConverter => Converter > MemberConverter.None;
+    public string PayloadInterfaceType => Converter == MemberConverter.RawPayload
+        ? "ArraySegment<byte>"
+        : TemplateHelper.GetInterfaceType(Type, Length);
 }
 
 public class PayloadMemberInfo
@@ -62,11 +72,13 @@ public class PayloadMemberInfo
     public int? Offset;
     public string MaskType;
     public string InterfaceType;
-    public string Converter;
+    public MemberConverter Converter;
     public string Description = "";
     public float? MinValue;
     public float? MaxValue;
     public float? DefaultValue;
+
+    public bool HasConverter => Converter > MemberConverter.None;
 }
 
 public class BitMaskInfo
@@ -192,17 +204,13 @@ public static partial class TemplateHelper
 
     public static string GetParseConversion(RegisterInfo register, string expression)
     {
-        var converter = register.Converter;
-        if (!string.IsNullOrEmpty(converter)) return $"{converter}({expression})";
-        if (register.PayloadSpec != null) return $"ParsePayload({expression})";
+        if (register.PayloadSpec != null || register.HasConverter) return $"ParsePayload({expression})";
         return GetConversionToInterfaceType(register.InterfaceType ?? register.MaskType, expression);
     }
 
     public static string GetFormatConversion(RegisterInfo register, string expression)
     {
-        var converter = register.Converter;
-        if (!string.IsNullOrEmpty(converter)) return $"{converter}({expression})";
-        if (register.PayloadSpec != null) return $"FormatPayload({expression})";
+        if (register.PayloadSpec != null || register.HasConverter) return $"FormatPayload({expression})";
         return GetConversionFromInterfaceType(register.InterfaceType ?? register.MaskType, register.PayloadInterfaceType, expression);
     }
 
@@ -236,6 +244,7 @@ public static partial class TemplateHelper
     }
 
     public static string GetPayloadMemberParser(
+        string name,
         PayloadMemberInfo member,
         string expression,
         PayloadType payloadType)
@@ -249,7 +258,7 @@ public static partial class TemplateHelper
             var mask = member.Mask.Value;
             var shift = GetMaskShift(mask);
             expression = $"({expression} & 0x{mask.ToString("X")})";
-            if (member.InterfaceType != "bool")
+            if (member.InterfaceType != "bool" || member.HasConverter)
             {
                 if (shift > 0)
                 {
@@ -261,25 +270,25 @@ public static partial class TemplateHelper
             }
         }
 
-        expression = GetConversionToInterfaceType(member.InterfaceType ?? member.MaskType, expression);
-        if (!string.IsNullOrEmpty(member.Converter))
+        if (member.HasConverter)
         {
-            expression = $"{member.Converter}({expression})";
+            return $"ParsePayload{name}({expression})";
         }
-        return expression;
+        return GetConversionToInterfaceType(member.InterfaceType ?? member.MaskType, expression);
     }
 
     public static string GetPayloadMemberFormatter(
+        string name,
         PayloadMemberInfo member,
         string expression,
         PayloadType payloadType,
         bool assigned)
     {
-        if (!string.IsNullOrEmpty(member.Converter))
+        if (member.HasConverter)
         {
-            expression = $"{member.Converter}({expression})";
+            expression = $"FormatPayload{name}({expression})";
         }
-        var isBoolean = member.InterfaceType == "bool";
+        var isBoolean = member.InterfaceType == "bool" && !member.HasConverter;
         var payloadInterfaceType = GetInterfaceType(payloadType);
         if (!string.IsNullOrEmpty(member.InterfaceType ?? member.MaskType))
         {

--- a/schema/registers.json
+++ b/schema/registers.json
@@ -84,8 +84,9 @@
             "type": "string"
         },
         "converter": {
-            "description": "Specifies a custom converter method used to parse or format the payload value in the high-level interface.",
-            "type": "string"
+            "description": "Specifies whether a custom converter will be used to parse or format the payload value.",
+            "type": "string",
+            "enum": ["None", "Payload", "RawPayload"]
         },
         "minValue": {
             "description": "Specifies the minimum allowable value for the payload or payload member.",


### PR DESCRIPTION
This PR automatically generates declaration stubs for converter methods. These can be auto-completed by the IDE in the corresponding register partial class, which greatly improves the developer experience.

The converter schema definition has been constrained into an enum type to allow support for converting from the extracted payload value, or from the raw payload buffer (without copying) to enable more efficient conversions such as high-level strings or matrix types.