### PR TITLE
Add register payload static metadata

### DIFF
--- a/interface/Device.tt
+++ b/interface/Device.tt
@@ -224,6 +224,16 @@ foreach (var registerMetadata in publicRegisters)
         /// Represents the address of the <see cref="<#= registerMetadata.Key #>"/> register. This field is constant.
         /// </summary>
         public const int Address = <#= register.Address #>;
+
+        /// <summary>
+        /// Represents the payload type of the <see cref="<#= registerMetadata.Key #>"/> register. This field is constant.
+        /// </summary>
+        public const PayloadType RegisterType = PayloadType.<#= register.Type #>;
+
+        /// <summary>
+        /// Represents the length of the <see cref="<#= registerMetadata.Key #>"/> register. This field is constant.
+        /// </summary>
+        public const int RegisterLength = <#= Math.Max(1, register.Length) #>;
 <#
     if (hasEvent || !allowWrite)
     {


### PR DESCRIPTION
This PR adds missing static metadata as constant fields in each generated register class. This allows access to this information in the custom converter methods, or as meta-information in high-level scripts.