### PR TITLE
Generate device identity class as a constant field

### DIFF
--- a/interface/AsyncDevice.tt
+++ b/interface/AsyncDevice.tt
@@ -36,8 +36,8 @@ namespace <#= Namespace #>
         public static async Task<AsyncDevice> CreateAsync(string portName)
         {
             var device = new AsyncDevice(portName);
-            var whoAmI = await device.ReadUInt16Async(DeviceRegisters.WhoAmI);
-            if (whoAmI != <#= deviceMetadata.WhoAmI #>)
+            var whoAmI = await device.ReadWhoAmIAsync();
+            if (whoAmI != Device.WhoAmI)
             {
                 var errorMessage = string.Format(
                     "The device ID {1} on {0} was unexpected. Check whether a <#= deviceName #> device is connected to the specified serial port.",

--- a/interface/Device.tt
+++ b/interface/Device.tt
@@ -39,9 +39,15 @@ namespace <#= Namespace #>
     public partial class Device : Bonsai.Harp.Device, INamedElement
     {
         /// <summary>
-        /// Initializes a new instance of the <see cref="Device" class.
+        /// Represents the unique identity class of the <see cref="<#= deviceName #>"/> device.
+        /// This field is constant.
         /// </summary>
-        public Device() : base(whoAmI: <#= deviceMetadata.WhoAmI #>) { }
+        public const int WhoAmI = <#= deviceMetadata.WhoAmI #>;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Device"/> class.
+        /// </summary>
+        public Device() : base(WhoAmI) { }
 
         string INamedElement.Name => nameof(<#= deviceName #>);
 


### PR DESCRIPTION
This PR allows the unique device identity class to be manipulated through a constant field in the generated Device class. This allows retrieving this piece of metadata programmatically.