### PR TITLE
Include all public registers in CreateMessage

### DIFF
--- a/interface/Device.tt
+++ b/interface/Device.tt
@@ -11,7 +11,6 @@
 <#
 var deviceMetadata = TemplateHelper.ReadDeviceMetadata(MetadataPath);
 var publicRegisters = deviceMetadata.Registers.Where(register => register.Value.Visibility == RegisterVisibility.Public).ToList();
-var writeRegisters = publicRegisters.Where(register => (register.Value.Access & RegisterAccess.Write) != 0).ToList();
 var deviceName = deviceMetadata.Device;
 #>
 using Bonsai;
@@ -500,20 +499,13 @@ foreach (var registerMetadata in publicRegisters)
 <#
 }
 #>
-<#
-} // publicRegisters.Count > 0
-#>
-<#
-if (writeRegisters.Count > 0)
-{
-#>
 
     /// <summary>
     /// Represents an operator which creates standard message payloads for the
     /// <#= deviceName #> device.
     /// </summary>
 <#
-foreach (var register in writeRegisters)
+foreach (var register in publicRegisters)
 {
 #>
     /// <seealso cref="Create<#= register.Key #>Payload"/>
@@ -521,7 +513,7 @@ foreach (var register in writeRegisters)
 }
 #>
 <#
-foreach (var register in writeRegisters)
+foreach (var register in publicRegisters)
 {
 #>
     [XmlInclude(typeof(Create<#= register.Key #>Payload))]
@@ -536,13 +528,13 @@ foreach (var register in writeRegisters)
         /// </summary>
         public CreateMessage()
         {
-            Payload = new Create<#= writeRegisters.First().Key #>Payload();
+            Payload = new Create<#= publicRegisters.First().Key #>Payload();
         }
 
         string INamedElement.Name => $"{nameof(<#= deviceName #>)}.{GetElementDisplayName(Payload)}";
     }
 <#
-foreach (var registerMetadata in writeRegisters)
+foreach (var registerMetadata in publicRegisters)
 {
     var register = registerMetadata.Value;
     var interfaceType = TemplateHelper.GetInterfaceType(registerMetadata.Key, register);
@@ -672,7 +664,7 @@ foreach (var registerMetadata in writeRegisters)
 }
 #>
 <#
-} // writeRegisters.Count > 0
+} // publicRegisters.Count > 0
 #>
 <#
 var payloadTypes = new HashSet<string>();


### PR DESCRIPTION
This PR updates the generation of `CreateMessage` payload operators to include all public registers in the device. This will ensure parity and consistency across all operators and facilitate implementation of virtual simulated devices.