### PR TITLE
Fix default filter register initialization

### DIFF
--- a/interface/Device.tt
+++ b/interface/Device.tt
@@ -122,7 +122,7 @@ foreach (var register in publicRegisters)
         /// </summary>
         public FilterMessage()
         {
-            Register = new Bonsai.Expressions.TypeMapping<<#= publicRegisters.First().Key #>>();
+            Register = new <#= publicRegisters.First().Key #>();
         }
 
         string INamedElement.Name


### PR DESCRIPTION
Fixes default register type initialization in auto-generated `FilterMessage` operator. The simple default constructor should be used instead of the legacy type mapping approach.