### PR TITLE
Fix INamedElement implementation for FilterMessage

### DIFF
--- a/interface/Device.tt
+++ b/interface/Device.tt
@@ -127,7 +127,7 @@ foreach (var register in publicRegisters)
 
         string INamedElement.Name
         {
-            get => $"{nameof(<#= deviceName #>)}.{GetElementDisplayName(Register?.GetType().GenericTypeArguments[0])}";
+            get => $"{nameof(<#= deviceName #>)}.{GetElementDisplayName(Register)}";
         }
     }
 


### PR DESCRIPTION
Fixes the auto-generation of operator names for the `FilterMessage` operator from the legacy type mapping strategy.