### PR TITLE
Add default zero value for generated bitmask types

### DIFF
--- a/interface/Device.tt
+++ b/interface/Device.tt
@@ -696,10 +696,15 @@ foreach (var bitMask in deviceMetadata.BitMasks)
 <#
     if (!mask.Bits.Values.Any(fieldInfo => fieldInfo.Value == 0))
     {
+        if (mask.Bits.Values.Any(fieldInfo => !string.IsNullOrEmpty(fieldInfo.Description)))
+        {
 #>
         /// <summary>
         /// Specifies that no flags are defined.
         /// </summary>
+<#
+        }
+#>
         None = 0x0<#= mask.Bits.Count > 0 ? "," : string.Empty #>
 <#
     }

--- a/interface/Device.tt
+++ b/interface/Device.tt
@@ -694,8 +694,11 @@ foreach (var bitMask in deviceMetadata.BitMasks)
     public enum <#= bitMask.Key #> : <#= mask.InterfaceType #>
     {
 <#
+    var bitIndex = 0;
+    var bitCount = mask.Bits.Count;
     if (!mask.Bits.Values.Any(fieldInfo => fieldInfo.Value == 0))
     {
+        bitCount++;
         if (mask.Bits.Values.Any(fieldInfo => !string.IsNullOrEmpty(fieldInfo.Description)))
         {
 #>
@@ -705,11 +708,10 @@ foreach (var bitMask in deviceMetadata.BitMasks)
 <#
         }
 #>
-        None = 0x0<#= mask.Bits.Count > 0 ? "," : string.Empty #>
+        None = 0x0<#= ++bitIndex < bitCount ? "," : string.Empty #>
 <#
     }
 
-    var bitIndex = 0;
     foreach (var bitField in mask.Bits)
     {
         var fieldInfo = bitField.Value;
@@ -725,7 +727,7 @@ foreach (var bitMask in deviceMetadata.BitMasks)
 <#
         }
 #>
-        <#= bitField.Key #> = 0x<#= fieldInfo.Value.ToString("X") #><#= ++bitIndex < mask.Bits.Count ? "," : string.Empty #>
+        <#= bitField.Key #> = 0x<#= fieldInfo.Value.ToString("X") #><#= ++bitIndex < bitCount ? "," : string.Empty #>
 <#
     }
 #>

--- a/interface/Device.tt
+++ b/interface/Device.tt
@@ -694,6 +694,16 @@ foreach (var bitMask in deviceMetadata.BitMasks)
     public enum <#= bitMask.Key #> : <#= mask.InterfaceType #>
     {
 <#
+    if (!mask.Bits.Values.Any(fieldInfo => fieldInfo.Value == 0))
+    {
+#>
+        /// <summary>
+        /// Specifies that no flags are defined.
+        /// </summary>
+        None = 0x0<#= mask.Bits.Count > 0 ? "," : string.Empty #>
+<#
+    }
+
     var bitIndex = 0;
     foreach (var bitField in mask.Bits)
     {

--- a/interface/Harp.Generators.csproj
+++ b/interface/Harp.Generators.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <VersionPrefix>0.1.0</VersionPrefix>
-    <VersionSuffix>build051802</VersionSuffix>
+    <VersionSuffix>build051806</VersionSuffix>
     <PackageId>Harp.Generators</PackageId>
     <Title>Harp Generators</Title>
     <Authors>harp-tech</Authors>

--- a/interface/Harp.Generators.csproj
+++ b/interface/Harp.Generators.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <VersionPrefix>0.1.0</VersionPrefix>
-    <VersionSuffix>build041201</VersionSuffix>
+    <VersionSuffix>build051802</VersionSuffix>
     <PackageId>Harp.Generators</PackageId>
     <Title>Harp Generators</Title>
     <Authors>harp-tech</Authors>


### PR DESCRIPTION
This PR adds support for automatically generating a default `None` bit field for the bit mask zero value (`0x0`). This is to improve readability of drop-downs in Bonsai and making sure that default property values follow a consistent naming convention.

Fixes #43 