### PR TITLE
Use register name for single property payload

### DIFF
--- a/interface/Device.tt
+++ b/interface/Device.tt
@@ -545,7 +545,7 @@ foreach (var registerMetadata in publicRegisters)
         }
 #>
         [Description("The value <#= summaryDescription #>.")]
-        public <#= interfaceType #> Value { get; set; }<#= defaultValue #>
+        public <#= interfaceType #> <#= registerMetadata.Key #> { get; set; }<#= defaultValue #>
 <#
     }
 #>
@@ -594,14 +594,14 @@ foreach (var registerMetadata in publicRegisters)
 <#
         }
 #>
-                return <#= registerMetadata.Key #>.FromPayload(MessageType, value);
+                return <#= Namespace #>.<#= registerMetadata.Key #>.FromPayload(MessageType, value);
             });
 <#
     }
     else
     {
 #>
-            return source.Select(_ => <#= registerMetadata.Key #>.FromPayload(MessageType, Value));
+            return source.Select(_ => <#= Namespace #>.<#= registerMetadata.Key #>.FromPayload(MessageType, <#= registerMetadata.Key #>));
 <#
     }
 #>


### PR DESCRIPTION
This PR changes the naming convention for auto-generated `CreateMessage` types. Instead of using the generic name `Value` to identify the property in single value registers, the name of the register itself is used instead. The new implementation also safeguards against complex payload specs that declare a property whose name clashes with the register name.