### PR TITLE
Rename register filter to match base class

### DIFF
--- a/interface/Device.tt
+++ b/interface/Device.tt
@@ -115,12 +115,12 @@ foreach (var register in publicRegisters)
 }
 #>
     [Description("Filters register-specific messages reported by the <#= deviceName #> device.")]
-    public class FilterMessage : FilterMessageBuilder, INamedElement
+    public class FilterRegister : FilterRegisterBuilder, INamedElement
     {
         /// <summary>
-        /// Initializes a new instance of the <see cref="FilterMessage"/> class.
+        /// Initializes a new instance of the <see cref="FilterRegister"/> class.
         /// </summary>
-        public FilterMessage()
+        public FilterRegister()
         {
             Register = new <#= publicRegisters.First().Key #>();
         }


### PR DESCRIPTION
Interface generation is updated to match the refactoring in https://github.com/bonsai-rx/harp/pull/64. This PR should be merged when the upstream is merged, and new preview interfaces should be regenerated for existing devices.