### PR TITLE
Add cancellation support to async device API

### DIFF
--- a/interface/AsyncDevice.tt
+++ b/interface/AsyncDevice.tt
@@ -14,6 +14,7 @@ var publicRegisters = deviceMetadata.Registers.Where(register => register.Value.
 var deviceName = deviceMetadata.Device;
 #>
 using Bonsai.Harp;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace <#= Namespace #>
@@ -69,26 +70,32 @@ foreach (var registerMetadata in publicRegisters)
         /// <summary>
         /// Asynchronously reads the contents of the <#= registerMetadata.Key #> register.
         /// </summary>
+        /// <param name="cancellationToken">
+        /// A <see cref="CancellationToken"/> which can be used to cancel the operation.
+        /// </param>
         /// <returns>
         /// A task that represents the asynchronous read operation. The <see cref="Task{TResult}.Result"/>
         /// property contains the register payload.
         /// </returns>
-        public async Task<<#= interfaceType #>> Read<#= registerMetadata.Key #>Async()
+        public async Task<<#= interfaceType #>> Read<#= registerMetadata.Key #>Async(CancellationToken cancellationToken = default)
         {
-            var reply = await CommandAsync(HarpCommand.Read<#= parsePayloadSuffix #>(<#= registerMetadata.Key #>.Address));
+            var reply = await CommandAsync(HarpCommand.Read<#= parsePayloadSuffix #>(<#= registerMetadata.Key #>.Address), cancellationToken);
             return <#= registerMetadata.Key #>.GetPayload(reply);
         }
 
         /// <summary>
         /// Asynchronously reads the timestamped contents of the <#= registerMetadata.Key #> register.
         /// </summary>
+        /// <param name="cancellationToken">
+        /// A <see cref="CancellationToken"/> which can be used to cancel the operation.
+        /// </param>
         /// <returns>
         /// A task that represents the asynchronous read operation. The <see cref="Task{TResult}.Result"/>
         /// property contains the timestamped register payload.
         /// </returns>
-        public async Task<Timestamped<<#= interfaceType #>>> ReadTimestamped<#= registerMetadata.Key #>Async()
+        public async Task<Timestamped<<#= interfaceType #>>> ReadTimestamped<#= registerMetadata.Key #>Async(CancellationToken cancellationToken = default)
         {
-            var reply = await CommandAsync(HarpCommand.Read<#= parsePayloadSuffix #>(<#= registerMetadata.Key #>.Address));
+            var reply = await CommandAsync(HarpCommand.Read<#= parsePayloadSuffix #>(<#= registerMetadata.Key #>.Address), cancellationToken);
             return <#= registerMetadata.Key #>.GetTimestampedPayload(reply);
         }
 <#
@@ -100,11 +107,14 @@ foreach (var registerMetadata in publicRegisters)
         /// Asynchronously writes a value to the <#= registerMetadata.Key #> register.
         /// </summary>
         /// <param name="value">The value to be stored in the register.</param>
+        /// <param name="cancellationToken">
+        /// A <see cref="CancellationToken"/> which can be used to cancel the operation.
+        /// </param>
         /// <returns>The task object representing the asynchronous write operation.</returns>
-        public async Task Write<#= registerMetadata.Key #>Async(<#= interfaceType #> value)
+        public async Task Write<#= registerMetadata.Key #>Async(<#= interfaceType #> value, CancellationToken cancellationToken = default)
         {
             var request = <#= registerMetadata.Key #>.FromPayload(MessageType.Write, value);
-            await CommandAsync(request);
+            await CommandAsync(request, cancellationToken);
         }
 <#
     }

--- a/interface/Harp.Generators.csproj
+++ b/interface/Harp.Generators.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <VersionPrefix>0.1.0</VersionPrefix>
-    <VersionSuffix>build060202</VersionSuffix>
+    <VersionSuffix>build062701</VersionSuffix>
     <PackageId>Harp.Generators</PackageId>
     <Title>Harp Generators</Title>
     <Authors>harp-tech</Authors>
@@ -20,7 +20,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Bonsai.Harp" Version="3.5.0-build032701" />
+    <PackageReference Include="Bonsai.Harp" Version="3.5.0-build062701" />
     <PackageReference Include="YamlDotNet" Version="13.0.2" />
   </ItemGroup>
 

--- a/template/Bonsai.DeviceTemplate/Generators/Generators.csproj
+++ b/template/Bonsai.DeviceTemplate/Generators/Generators.csproj
@@ -15,7 +15,7 @@
     <FirmwarePath>..\Firmware\$projectname$</FirmwarePath>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Harp.Generators" Version="0.1.0" GeneratePathProperty="true" />
+    <PackageReference Include="Harp.Generators" Version="0.1.0-build062701" GeneratePathProperty="true" />
   </ItemGroup>
   <Target Name="TextTransform" BeforeTargets="AfterBuild">
     <PropertyGroup>

--- a/template/Harp.Templates.csproj
+++ b/template/Harp.Templates.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <PackageType>Template</PackageType>
     <VersionPrefix>0.1.0</VersionPrefix>
-    <VersionSuffix>preview7</VersionSuffix>
+    <VersionSuffix>preview10</VersionSuffix>
     <PackageId>Harp.Templates</PackageId>
     <Title>Harp Templates</Title>
     <Authors>harp-tech</Authors>


### PR DESCRIPTION
This PR adds cancellation support for all auto-generated async device APIs following the pattern introduced in https://github.com/bonsai-rx/harp/pull/65. Assuming Python.NET deals well with optional parameters it shouldn't change anything about the current API, and introduces a more flexible framework for cancelling pending operations.