### PR TITLE
Update notice and package first stable version

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2023 harp-tech
+Copyright (c) 2023 harp-tech and Contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/interface/Harp.Generators.csproj
+++ b/interface/Harp.Generators.csproj
@@ -9,6 +9,9 @@
     <Copyright>Copyright © harp-tech and Contributors 2023</Copyright>
     <Description>Provides source generators for Harp device firmware and software interface.</Description>
     <PackageTags>Harp Device Firmware Interface Generators</PackageTags>
+    <PackageProjectUrl>https://harp-tech.org</PackageProjectUrl>
+    <RepositoryUrl>https://github.com/harp-tech/reflex-generator.git</RepositoryUrl>
+    <RepositoryType>git</RepositoryType>
     <PackageIcon>icon.png</PackageIcon>
     <PackageLicenseFile>LICENSE</PackageLicenseFile>
     <PackageOutputPath>.\</PackageOutputPath>

--- a/interface/Harp.Generators.csproj
+++ b/interface/Harp.Generators.csproj
@@ -2,11 +2,11 @@
 
   <PropertyGroup>
     <VersionPrefix>0.1.0</VersionPrefix>
-    <VersionSuffix>build062701</VersionSuffix>
+    <VersionSuffix></VersionSuffix>
     <PackageId>Harp.Generators</PackageId>
     <Title>Harp Generators</Title>
     <Authors>harp-tech</Authors>
-    <Copyright>Copyright © harp-tech 2023</Copyright>
+    <Copyright>Copyright © harp-tech and Contributors 2023</Copyright>
     <Description>Provides source generators for Harp device firmware and software interface.</Description>
     <PackageTags>Harp Device Firmware Interface Generators</PackageTags>
     <PackageIcon>icon.png</PackageIcon>
@@ -20,7 +20,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Bonsai.Harp" Version="3.5.0-build062701" />
+    <PackageReference Include="Bonsai.Harp" Version="3.5.0" />
     <PackageReference Include="YamlDotNet" Version="13.0.2" />
   </ItemGroup>
 

--- a/template/Bonsai.DeviceTemplate/Generators/Generators.csproj
+++ b/template/Bonsai.DeviceTemplate/Generators/Generators.csproj
@@ -15,7 +15,7 @@
     <FirmwarePath>..\Firmware\$projectname$</FirmwarePath>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Harp.Generators" Version="0.1.0-build062701" GeneratePathProperty="true" />
+    <PackageReference Include="Harp.Generators" Version="0.1.0" GeneratePathProperty="true" />
   </ItemGroup>
   <Target Name="TextTransform" BeforeTargets="AfterBuild">
     <PropertyGroup>

--- a/template/Bonsai.DeviceTemplate/Interface/DeviceTemplate/DeviceTemplate.csproj
+++ b/template/Bonsai.DeviceTemplate/Interface/DeviceTemplate/DeviceTemplate.csproj
@@ -20,7 +20,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Bonsai.Harp" Version="3.5.0-build032701" />
+    <PackageReference Include="Bonsai.Harp" Version="3.5.0" />
   </ItemGroup>
 
 </Project>

--- a/template/Harp.Templates.csproj
+++ b/template/Harp.Templates.csproj
@@ -10,6 +10,9 @@
     <Copyright>Copyright © harp-tech and Contributors 2023</Copyright>
     <Description>Templates for creating a new Harp device</Description>
     <PackageTags>Harp Device Firmware Hardware Interface Templates</PackageTags>
+    <PackageProjectUrl>https://harp-tech.org</PackageProjectUrl>
+    <RepositoryUrl>https://github.com/harp-tech/reflex-generator.git</RepositoryUrl>
+    <RepositoryType>git</RepositoryType>
     <PackageIcon>icon.png</PackageIcon>
     <PackageLicenseFile>LICENSE</PackageLicenseFile>
     <PackageOutputPath>.\</PackageOutputPath>

--- a/template/Harp.Templates.csproj
+++ b/template/Harp.Templates.csproj
@@ -3,11 +3,11 @@
   <PropertyGroup>
     <PackageType>Template</PackageType>
     <VersionPrefix>0.1.0</VersionPrefix>
-    <VersionSuffix>preview10</VersionSuffix>
+    <VersionSuffix></VersionSuffix>
     <PackageId>Harp.Templates</PackageId>
     <Title>Harp Templates</Title>
     <Authors>harp-tech</Authors>
-    <Copyright>Copyright © harp-tech 2023</Copyright>
+    <Copyright>Copyright © harp-tech and Contributors 2023</Copyright>
     <Description>Templates for creating a new Harp device</Description>
     <PackageTags>Harp Device Firmware Hardware Interface Templates</PackageTags>
     <PackageIcon>icon.png</PackageIcon>


### PR DESCRIPTION
This PR removes all pre-release suffixes and packages the first stable version of both the interface generator and project templates for creating new devices.

The copyright notice was also updated to include "and Contributors" to be more inclusive and explicit of all contributions to the project.