### PR TITLE
Update template to improve debugging experience

### DIFF
--- a/template/Bonsai.DeviceTemplate/Interface/DeviceTemplate/Properties/launchSettings.json
+++ b/template/Bonsai.DeviceTemplate/Interface/DeviceTemplate/Properties/launchSettings.json
@@ -2,8 +2,9 @@
   "profiles": {
     "Bonsai": {
       "commandName": "Executable",
-      "executablePath": "$(registry:HKEY_CURRENT_USER\\Software\\Goncalo Lopes\\Bonsai@InstallDir)Bonsai.exe",
-      "commandLineArgs": "--lib:$(TargetDir)."
+      "executablePath": "$(registry:HKEY_CURRENT_USER\\Software\\Bonsai Foundation\\Bonsai@InstallDir)Bonsai.exe",
+      "commandLineArgs": "--lib:$(TargetDir).",
+      "nativeDebugging": true
     }
   }
 }

--- a/template/Harp.Templates.csproj
+++ b/template/Harp.Templates.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <PackageType>Template</PackageType>
-    <VersionPrefix>0.1.0</VersionPrefix>
+    <VersionPrefix>0.1.1</VersionPrefix>
     <VersionSuffix></VersionSuffix>
     <PackageId>Harp.Templates</PackageId>
     <Title>Harp Templates</Title>


### PR DESCRIPTION
This PR updates the template launch settings to configure native debugging and target the environment variables used by Bonsai 2.8. This makes it easier to debug projects in the new version.