### PR TITLE
Update register schema to conform to standard JSON rules

### DIFF
--- a/interface/Interface.tt
+++ b/interface/Interface.tt
@@ -350,6 +350,10 @@ class MaskValueTypeConverter : IYamlTypeConverter
                 {
                     maskValue.Value = ValueDeserializer.Deserialize<int>(key.Value);
                 }
+                else if (key.Value.Equals(nameof(maskValue.Value), StringComparison.OrdinalIgnoreCase))
+                {
+                    maskValue.Value = ValueDeserializer.Deserialize<int>(value.Value);
+                }
                 else if (key.Value.Equals(nameof(maskValue.Description), StringComparison.OrdinalIgnoreCase))
                 {
                     maskValue.Description = value.Value;

--- a/schema/common.yml
+++ b/schema/common.yml
@@ -109,37 +109,37 @@ groupMasks:
   OperationMode:
     description: Specifies the operation mode of the device.
     values:
-      Standby: {0, description: Disable all event reporting on the device.}
-      Active: {1, description: Event detection is enabled. Only enabled events are reported by the device.}
-      Speed: {3, description: The device enters speed mode.}
+      Standby: {value: 0, description: Disable all event reporting on the device.}
+      Active: {value: 1, description: Event detection is enabled. Only enabled events are reported by the device.}
+      Speed: {value: 3, description: The device enters speed mode.}
   EnableFlag:
     description: Specifies whether a specific register flag is enabled or disabled.
     values:
-      Disabled: {0, description: Specifies that the flag is disabled.}
-      Enabled: {1, description: Specifies that the flag is enabled.}
+      Disabled: {value: 0, description: Specifies that the flag is disabled.}
+      Enabled: {value: 1, description: Specifies that the flag is enabled.}
   LedState:
     description: Specifies the state of an LED on the device.
     values:
-      Off: {0, description: Specifies that the LED is off.}
-      On: {1, description: Specifies that the LED is on.}
+      Off: {value: 0, description: Specifies that the LED is off.}
+      On: {value: 1, description: Specifies that the LED is on.}
 bitMasks:
   ResetFlags:
     description: Specifies the behavior of the non-volatile registers when resetting the device.
     bits:
-      None: {0, description: All reset flags are cleared.}
-      RestoreDefault: {0x1, description: The device will boot with all the registers reset to their default factory values.}
-      RestoreEeprom: {0x2, description: The device will boot and restore all the registers to the values stored in non-volatile memory.}
-      Save: {0x4, description: The device will boot and save all the current register values to non-volatile memory.}
-      RestoreName: {0x8, description: The device will boot with the default device name.}
-      BootFromDefault: {0x40, description: Specifies that the device has booted from default factory values.}
-      BootFromEeprom: {0x80, description: Specifies that the device has booted from non-volatile values stored in EEPROM.}
+      None: {value: 0, description: All reset flags are cleared.}
+      RestoreDefault: {value: 0x1, description: The device will boot with all the registers reset to their default factory values.}
+      RestoreEeprom: {value: 0x2, description: The device will boot and restore all the registers to the values stored in non-volatile memory.}
+      Save: {value: 0x4, description: The device will boot and save all the current register values to non-volatile memory.}
+      RestoreName: {value: 0x8, description: The device will boot with the default device name.}
+      BootFromDefault: {value: 0x40, description: Specifies that the device has booted from default factory values.}
+      BootFromEeprom: {value: 0x80, description: Specifies that the device has booted from non-volatile values stored in EEPROM.}
   ClockConfigurationFlags:
     description: Specifies configuration flags for the device synchronization clock.
     bits:
-      None: {0, description: All clock configuration flags are cleared.}
-      ClockRepeater: {0x1, description: "The device will repeat the clock synchronization signal to the clock output connector, if available."}
-      ClockGenerator: {0x2, description: "The device resets and generates the clock synchronization signal on the clock output connector, if available."}
-      RepeaterCapability: {0x8, description: Specifies the device has the capability to repeat the clock synchronization signal to the clock output connector.}
-      GeneratorCapability: {0x10, description: Specifies the device has the capability to generate the clock synchronization signal to the clock output connector.}
-      ClockUnlock: {0x40, description: The device will unlock the timestamp register counter and will accept commands to set new timestamp values.}
-      ClockLock: {0x80, description: The device will lock the timestamp register counter and will not accept commands to set new timestamp values.}
+      None: {value: 0, description: All clock configuration flags are cleared.}
+      ClockRepeater: {value: 0x1, description: "The device will repeat the clock synchronization signal to the clock output connector, if available."}
+      ClockGenerator: {value: 0x2, description: "The device resets and generates the clock synchronization signal on the clock output connector, if available."}
+      RepeaterCapability: {value: 0x8, description: Specifies the device has the capability to repeat the clock synchronization signal to the clock output connector.}
+      GeneratorCapability: {value: 0x10, description: Specifies the device has the capability to generate the clock synchronization signal to the clock output connector.}
+      ClockUnlock: {value: 0x40, description: The device will unlock the timestamp register counter and will accept commands to set new timestamp values.}
+      ClockLock: {value: 0x80, description: The device will lock the timestamp register counter and will not accept commands to set new timestamp values.}

--- a/schema/device.json
+++ b/schema/device.json
@@ -1,6 +1,6 @@
 {
     "$schema": "https://json-schema.org/draft-07/schema",
-    "$id": "https://harp-tech.org/2023-01/device",
+    "$id": "https://harp-tech.org/draft-02/schema/device.json",
     "type": "object",
     "allOf": [
         {

--- a/schema/example.yml
+++ b/schema/example.yml
@@ -72,5 +72,5 @@ bitMasks:
   DO:
     description: Bitmask representing the state of the digital outputs.
     bits:
-      DO0: {0x01, description: The state of digital output pin 0.}
-      DO1: {0x02, description: The state of digital output pin 1.}
+      DO0: {value: 0x01, description: The state of digital output pin 0.}
+      DO1: {value: 0x02, description: The state of digital output pin 1.}

--- a/schema/ios.json
+++ b/schema/ios.json
@@ -1,6 +1,6 @@
 {
     "$schema": "https://json-schema.org/draft-07/schema",
-    "$id": "https://harp-tech.org/2023-02/ios",
+    "$id": "https://harp-tech.org/draft-02/schema/ios.json",
     "type": "object",
     "description": "Specifies the IO pin configuration used to automatically generate firmware.",
     "additionalProperties": {

--- a/schema/registers.json
+++ b/schema/registers.json
@@ -1,6 +1,6 @@
 {
     "$schema": "https://json-schema.org/draft-07/schema",
-    "$id": "https://harp-tech.org/2023-03/registers",
+    "$id": "https://harp-tech.org/draft-02/schema/registers.json",
     "type": "object",
     "properties": {
         "registers": {

--- a/schema/registers.json
+++ b/schema/registers.json
@@ -36,11 +36,16 @@
                 {
                     "type": "object",
                     "properties": {
+                        "value": {
+                            "description": "Specifies the numerical mask value.",
+                            "type": "integer"
+                        },
                         "description": {
                             "description": "Specifies a summary description of the mask value function.",
                             "type": "string"
                         }
                     },
+                    "required": ["value"],
                     "additionalProperties": false
                 }
             ]


### PR DESCRIPTION
The original register schema exploited a YAML-specific quirk to make the syntax for individual mask value descriptions slightly more compact (see #14). Specifically, it was possible to write the following:

```yaml
EnableFlag:
  description: Specifies whether a specific register flag is enabled or disabled.
  values:
    Disabled: {0, description: Specifies that the flag is disabled.}
    Enabled: {1, description: Specifies that the flag is enabled.}
```

The exploit takes advantage of the fact that YAML mappings accept integers as keys (this is not valid JSON where all keys must be strings), and that the value of a mapping can be left unspecified. Essentially the "lone" number in the dictionary is a key with no value. However, there was not really any way in JSON-schema of specifying that this rogue key had to be an integer, or indeed that a key with no value was required at all.

While the original format is compatible with YamlDotNet, it turns out not to be accepted by other JSON-schema compatible YAML parsers, and specifically it is not compatible with Pydantic.

To make the whole specification more compliant with standard JSON-schema, we propose modifying the register schema to be explicit and require a "value" key in the mapping when a description is provided. This means the group mask above will now be written as follows:

```yaml
EnableFlag:
  description: Specifies whether a specific register flag is enabled or disabled.
  values:
    Disabled: {value: 0, description: Specifies that the flag is disabled.}
    Enabled: {value: 1, description: Specifies that the flag is enabled.}
```

It is not really that different in practice and plays much better with existing tooling. The interface generators have been updated to be backwards-compatible so that any existing schemas using the legacy feature will not break.