### PR TITLE
Generate ToString method for custom payload types

### DIFF
--- a/interface/Device.tt
+++ b/interface/Device.tt
@@ -697,6 +697,29 @@ foreach (var registerMetadata in deviceRegisters)
 <#
     }
 #>
+
+        /// <summary>
+        /// Returns a <see cref="string"/> that represents the payload of
+        /// the <#= registerName #> register.
+        /// </summary>
+        /// <returns>
+        /// A <see cref="string"/> that represents the payload of the
+        /// <#= registerName #> register.
+        /// </returns>
+        public override string ToString()
+        {
+            return "<#= interfaceType #> { " +
+<#
+    var memberIndex = 0;
+    foreach (var member in register.PayloadSpec)
+    {
+#>
+                "<#= member.Key #> = " + <#= member.Key #> + "<#= ++memberIndex < register.PayloadSpec.Count ? ", " : " " #>" +
+<#
+    }
+#>
+            "}";
+        }
     }
 <#
 }


### PR DESCRIPTION
To improve the experience of using custom payload types this PR automatically generates a `ToString()` override following the convention of C# [record types](https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/builtin-types/record).

Specifically, for a payload `RgbPayload` with the following spec:

```yaml
payloadSpec:
  Green:
    offset: 0
    description: The intensity of the green channel in the RGB LED.
  Red:
    offset: 1
    description: The intensity of the red channel in the RGB LED.
  Blue:
    offset: 2
    description: The intensity of the blue channel in the RGB LED.
```

The following method is generated:

```c#
/// <summary>
/// Returns a <see cref="string"/> that represents the payload of
/// the Rgb register.
/// </summary>
/// <returns>
/// A <see cref="string"/> that represents the payload of the
/// Rgb register.
/// </returns>
public override string ToString()
{
    return "RgbPayload { " +
        "Green = " + Green + ", " +
        "Red = " + Red + ", " +
        "Blue = " + Blue + " " +
    "}";
}
```

Fixes #59 