### PR TITLE
Embed device metadata as part of interface project

### DIFF
--- a/interface/Device.tt
+++ b/interface/Device.tt
@@ -71,6 +71,30 @@ foreach (var register in deviceRegisters)
     }
 
     /// <summary>
+    /// Represents an operator that returns the contents of the metadata file
+    /// describing the <see cref="<#= deviceName #>"/> device registers.
+    /// </summary>
+    [Description("Returns the contents of the metadata file describing the <#= deviceName #> device registers.")]
+    public partial class DeviceMetadata : Source<string>
+    {
+        static readonly string Metadata = GetDeviceMetadata();
+
+        static string GetDeviceMetadata()
+        {
+            var metadataType = typeof(DeviceMetadata);
+            using var metadataStream = metadataType.Assembly.GetManifestResourceStream($"{metadataType.Namespace}.device.yml");
+            using var streamReader = new System.IO.StreamReader(metadataStream);
+            return streamReader.ReadToEnd();
+        }
+
+        /// <inheritdoc/>
+        public override IObservable<string> Generate()
+        {
+            return Observable.Return(Metadata);
+        }
+    }
+
+    /// <summary>
     /// Represents an operator that groups the sequence of <see cref="<#= deviceName #>"/>" messages by register type.
     /// </summary>
     [Description("Groups the sequence of <#= deviceName #> messages by register type.")]

--- a/interface/Harp.Generators.csproj
+++ b/interface/Harp.Generators.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <VersionPrefix>0.2.0</VersionPrefix>
+    <VersionPrefix>0.3.0</VersionPrefix>
     <VersionSuffix></VersionSuffix>
     <PackageId>Harp.Generators</PackageId>
     <Title>Harp Generators</Title>

--- a/template/Bonsai.DeviceTemplate/Generators/Generators.csproj
+++ b/template/Bonsai.DeviceTemplate/Generators/Generators.csproj
@@ -15,7 +15,7 @@
     <FirmwarePath>..\Firmware\$projectname$</FirmwarePath>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Harp.Generators" Version="0.1.0" GeneratePathProperty="true" />
+    <PackageReference Include="Harp.Generators" Version="0.3.0" GeneratePathProperty="true" />
   </ItemGroup>
   <Target Name="TextTransform" BeforeTargets="AfterBuild">
     <PropertyGroup>

--- a/template/Bonsai.DeviceTemplate/Interface/DeviceTemplate/DeviceTemplate.csproj
+++ b/template/Bonsai.DeviceTemplate/Interface/DeviceTemplate/DeviceTemplate.csproj
@@ -23,4 +23,8 @@
     <PackageReference Include="Bonsai.Harp" Version="3.5.0" />
   </ItemGroup>
 
+  <ItemGroup>
+    <EmbeddedResource Include="..\..\device.yml" />
+  </ItemGroup>
+
 </Project>

--- a/template/Harp.Templates.csproj
+++ b/template/Harp.Templates.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <PackageType>Template</PackageType>
-    <VersionPrefix>0.1.2</VersionPrefix>
+    <VersionPrefix>0.2.0</VersionPrefix>
     <VersionSuffix></VersionSuffix>
     <PackageId>Harp.Templates</PackageId>
     <Title>Harp Templates</Title>


### PR DESCRIPTION
Following discussions in https://github.com/harp-tech/protocol/issues/41, this PR modifies both the source generators and the harp device template to ensure the `device.yml` file is embedded directly as a resource file in the interface assembly.

This allows automatic generation of a new source `DeviceMetadata`, returning the full YML used to generate the C# interface. Sending the output of this source into `WriteAllText` can be used to ensure provenance metadata is saved alongside register data for all devices.

The current implementation of the generators assumes that the `device.yml` file is *always* declared as an `EmbeddedResource` in the device interface project. If this is not the case, the `DeviceMetadata` source will crash at runtime

Fixes #60 