### PR TITLE
Add library package type to project template

### DIFF
--- a/template/Bonsai.DeviceTemplate/Interface/DeviceTemplate/DeviceTemplate.csproj
+++ b/template/Bonsai.DeviceTemplate/Interface/DeviceTemplate/DeviceTemplate.csproj
@@ -9,6 +9,7 @@
     <GeneratePackageOnBuild Condition="'$(Configuration)'=='Release'">true</GeneratePackageOnBuild>
     <Description>Bonsai Library containing interfaces for data acquisition and control of $title$ devices.</Description>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <PackageType>Dependency;BonsaiLibrary</PackageType>
     <PackageTags>$title$ Bonsai Rx</PackageTags>
     <PackageProjectUrl></PackageProjectUrl>
     <PackageLicenseExpression></PackageLicenseExpression>

--- a/template/Harp.Templates.csproj
+++ b/template/Harp.Templates.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <PackageType>Template</PackageType>
-    <VersionPrefix>0.2.0</VersionPrefix>
+    <VersionPrefix>0.2.1</VersionPrefix>
     <VersionSuffix></VersionSuffix>
     <PackageId>Harp.Templates</PackageId>
     <Title>Harp Templates</Title>


### PR DESCRIPTION
This PR adds the new library package type `BonsaiLibrary` to the project template for all upcoming new device interfaces. This will make all device packages much easier to find in the next version of the package manager.