### PR TITLE
Add generator test infrastructure

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -1,0 +1,26 @@
+# This workflow will build and test the interface generators
+name: dotnet
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Setup .NET
+      uses: actions/setup-dotnet@v4
+      with:
+        dotnet-version: 8.0.x
+    - name: Restore dependencies
+      run: dotnet restore
+    - name: Build
+      run: dotnet build --no-restore
+    - name: Test
+      run: dotnet test --no-build --verbosity normal

--- a/Harp.Generators.sln
+++ b/Harp.Generators.sln
@@ -1,0 +1,33 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31903.59
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Harp.Generators", "interface\Harp.Generators.csproj", "{967ABE9B-502A-4EC4-8179-82A9B817E295}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "tests", "tests", "{DFD2ABB5-A6B9-4D19-9002-95D82E305497}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Interface.Tests", "tests\Interface.Tests\Interface.Tests.csproj", "{B2116B91-8305-494B-9599-35C600A50766}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{967ABE9B-502A-4EC4-8179-82A9B817E295}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{967ABE9B-502A-4EC4-8179-82A9B817E295}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{967ABE9B-502A-4EC4-8179-82A9B817E295}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{967ABE9B-502A-4EC4-8179-82A9B817E295}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B2116B91-8305-494B-9599-35C600A50766}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B2116B91-8305-494B-9599-35C600A50766}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B2116B91-8305-494B-9599-35C600A50766}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B2116B91-8305-494B-9599-35C600A50766}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+		{B2116B91-8305-494B-9599-35C600A50766} = {DFD2ABB5-A6B9-4D19-9002-95D82E305497}
+	EndGlobalSection
+EndGlobal

--- a/interface/Harp.Generators.csproj
+++ b/interface/Harp.Generators.csproj
@@ -20,6 +20,7 @@
     <IncludeContentInPack>true</IncludeContentInPack>
     <IncludeBuildOutput>false</IncludeBuildOutput>
     <ContentTargetFolders>contentFiles</ContentTargetFolders>
+    <NoPackageAnalysis>true</NoPackageAnalysis>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/Interface.Tests/GeneratorTests.cs
+++ b/tests/Interface.Tests/GeneratorTests.cs
@@ -1,0 +1,48 @@
+﻿using Mono.TextTemplating;
+
+namespace Interface.Tests;
+
+[TestClass]
+public sealed class GeneratorTests
+{
+    TemplateGenerator generator;
+    CompiledTemplate deviceTemplate;
+    CompiledTemplate asyncDeviceTemplate;
+
+    [TestInitialize]
+    public async Task Initialize()
+    {
+        generator = new TestTemplateGenerator();
+        var deviceTemplateContents = TestHelper.GetManifestResourceText("Device.tt");
+        var asyncDeviceTemplateContents = TestHelper.GetManifestResourceText("AsyncDevice.tt");
+        deviceTemplate = await generator.CompileTemplateAsync(deviceTemplateContents);
+        TestHelper.AssertNoGeneratorErrors(generator);
+
+        asyncDeviceTemplate = await generator.CompileTemplateAsync(asyncDeviceTemplateContents);
+        TestHelper.AssertNoGeneratorErrors(generator);
+    }
+
+    private string ProcessTemplate(CompiledTemplate template, string metadataFileName)
+    {
+        var session = generator.GetOrCreateSession();
+        session["Namespace"] = typeof(GeneratorTests).Namespace;
+        session["MetadataPath"] = Path.GetFullPath(Path.Combine("Metadata", metadataFileName));
+        return template.Process();
+    }
+
+    [DataTestMethod]
+    [DataRow("device.yml")]
+    public void DeviceTemplate_GenerateNoErrors(string metadataFileName)
+    {
+        ProcessTemplate(deviceTemplate, metadataFileName);
+        TestHelper.AssertNoGeneratorErrors(generator);
+    }
+
+    [DataTestMethod]
+    [DataRow("device.yml")]
+    public void AsyncDeviceTemplate_GenerateNoErrors(string metadataFileName)
+    {
+        ProcessTemplate(asyncDeviceTemplate, metadataFileName);
+        TestHelper.AssertNoGeneratorErrors(generator);
+    }
+}

--- a/tests/Interface.Tests/Interface.Tests.csproj
+++ b/tests/Interface.Tests/Interface.Tests.csproj
@@ -1,0 +1,31 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <LangVersion>latest</LangVersion>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Bonsai.Harp" Version="3.5.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="Mono.TextTemplating" Version="3.0.0" />
+    <PackageReference Include="MSTest" Version="3.6.4" />
+    <PackageReference Include="YamlDotNet" Version="13.0.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Microsoft.VisualStudio.TestTools.UnitTesting" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <EmbeddedResource Include="..\..\interface\*.tt" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Content Include="Metadata\*.yml">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
+  </ItemGroup>
+
+</Project>

--- a/tests/Interface.Tests/MSTestSettings.cs
+++ b/tests/Interface.Tests/MSTestSettings.cs
@@ -1,0 +1,1 @@
+﻿[assembly: Parallelize(Scope = ExecutionScope.MethodLevel)]

--- a/tests/Interface.Tests/Metadata/device.yml
+++ b/tests/Interface.Tests/Metadata/device.yml
@@ -1,0 +1,12 @@
+%YAML 1.1
+---
+# yaml-language-server: $schema=https://harp-tech.org/draft-02/schema/device.json
+device: Test
+whoAmI: 0000
+firmwareVersion: "0.1"
+hardwareTargets: "0.0"
+registers:
+  DigitalInputs:
+    address: 32
+    type: U8
+    access: Event

--- a/tests/Interface.Tests/TestHelper.cs
+++ b/tests/Interface.Tests/TestHelper.cs
@@ -1,0 +1,46 @@
+﻿using System.Text;
+using Mono.TextTemplating;
+
+namespace Interface.Tests;
+
+static class TestHelper
+{
+    public static Stream GetManifestResourceStream(string name)
+    {
+        var qualifierType = typeof(TestHelper);
+        var embeddedWorkflowStream = qualifierType.Namespace + "." + name;
+        return qualifierType.Assembly.GetManifestResourceStream(embeddedWorkflowStream)!;
+    }
+
+    public static string GetManifestResourceText(string name)
+    {
+        using var resourceStream = GetManifestResourceStream(name);
+        using var resourceReader = new StreamReader(resourceStream);
+        return resourceReader.ReadToEnd();
+    }
+
+    public static void AssertNoGeneratorErrors(TemplateGenerator generator)
+    {
+        if (generator.Errors.HasErrors)
+        {
+            Assert.Fail(GetGeneratorErrorMessage(generator));
+        }
+    }
+
+    public static string GetGeneratorErrorMessage(TemplateGenerator generator)
+    {
+        if (!generator.Errors.HasErrors)
+            return string.Empty;
+
+        var stringBuilder = new StringBuilder();
+        for (int i = 0; i < generator.Errors.Count; i++)
+        {
+            var error = generator.Errors[i];
+            stringBuilder.AppendLine(
+                $"({error.ErrorNumber}) {error.ErrorText} in {error.FileName}:line {error.Line}"
+            );
+        }
+
+        return stringBuilder.ToString();
+    }
+}

--- a/tests/Interface.Tests/TestTemplateGenerator.cs
+++ b/tests/Interface.Tests/TestTemplateGenerator.cs
@@ -1,0 +1,13 @@
+﻿using Mono.TextTemplating;
+
+namespace Interface.Tests;
+
+public class TestTemplateGenerator : TemplateGenerator
+{
+    protected override bool LoadIncludeText(string requestFileName, out string content, out string location)
+    {
+        content = TestHelper.GetManifestResourceText(requestFileName);
+        location = string.Empty;
+        return true;
+    }
+}


### PR DESCRIPTION
To support evolution of the Harp interface and firmware generators we need a test infrastructure. Here we add a fully automated .NET test project taking advantage of the [Mono.TextTemplating](https://github.com/mono/t4/blob/main/Mono.TextTemplating/readme.md) API.

This has the further advantage of leaving us one step closer to deploying a complete .NET tool for more flexible interface generation, e.g. to automatically generate the core register interface and experiment-specific virtual devices.