### PR TITLE
Update YamlDotNet version

### DIFF
--- a/build/Common.props
+++ b/build/Common.props
@@ -6,6 +6,6 @@
 
   <ItemGroup Condition="'$(MSBuildProjectName)' != 'Harp.Templates'">
     <PackageReference Include="Bonsai.Harp" Version="3.5.0" />
-    <PackageReference Include="YamlDotNet" Version="13.0.2" />
+    <PackageReference Include="YamlDotNet" Version="16.3.0" />
   </ItemGroup>
 </Project>

--- a/interface/Interface.tt
+++ b/interface/Interface.tt
@@ -337,7 +337,7 @@ class MaskValueTypeConverter : IYamlTypeConverter
         return type == typeof(MaskValue);
     }
 
-    public object ReadYaml(IParser parser, Type type)
+    public object ReadYaml(IParser parser, Type type, ObjectDeserializer rootDeserializer)
     {
         if (parser.TryConsume(out MappingStart _))
         {
@@ -368,7 +368,7 @@ class MaskValueTypeConverter : IYamlTypeConverter
         }
     }
 
-    public void WriteYaml(IEmitter emitter, object value, Type type)
+    public void WriteYaml(IEmitter emitter, object value, Type type, ObjectSerializer serializer)
     {
         throw new NotImplementedException();
     }
@@ -383,7 +383,7 @@ class RegisterAccessTypeConverter : IYamlTypeConverter
         return type == typeof(RegisterAccess);
     }
 
-    public object ReadYaml(IParser parser, Type type)
+    public object ReadYaml(IParser parser, Type type, ObjectDeserializer rootDeserializer)
     {
         if (parser.TryConsume(out SequenceStart _))
         {
@@ -402,7 +402,7 @@ class RegisterAccessTypeConverter : IYamlTypeConverter
         }
     }
 
-    public void WriteYaml(IEmitter emitter, object value, Type type)
+    public void WriteYaml(IEmitter emitter, object value, Type type, ObjectSerializer serializer)
     {
         throw new NotImplementedException();
     }


### PR DESCRIPTION
The new version of [YamlDotNet](https://github.com/aaubry/YamlDotNet) has some breaking changes in the type converter interface which require updating method signatures. We don't strictly need the new features, but this dependency was growing increasingly stale so probably better to keep it up to date.