### PR TITLE
Add CancellationToken to Device.CreateAsync method

### DIFF
--- a/interface/AsyncDevice.tt
+++ b/interface/AsyncDevice.tt
@@ -29,15 +29,18 @@ namespace <#= Namespace #>
         /// <param name="portName">
         /// The name of the serial port used to communicate with the Harp device.
         /// </param>
+        /// <param name="cancellationToken">
+        /// A <see cref="CancellationToken"/> which can be used to cancel the operation.
+        /// </param>
         /// <returns>
         /// A task that represents the asynchronous initialization operation. The value of
         /// the <see cref="Task{TResult}.Result"/> parameter contains a new instance of
         /// the <see cref="AsyncDevice"/> class.
         /// </returns>
-        public static async Task<AsyncDevice> CreateAsync(string portName)
+        public static async Task<AsyncDevice> CreateAsync(string portName, CancellationToken cancellationToken = default)
         {
             var device = new AsyncDevice(portName);
-            var whoAmI = await device.ReadWhoAmIAsync();
+            var whoAmI = await device.ReadWhoAmIAsync(cancellationToken);
             if (whoAmI != Device.WhoAmI)
             {
                 var errorMessage = string.Format(


### PR DESCRIPTION
If trying to connect to a non-Harp device, the ReadWhoAmIAsync on Device.CreateAsync call would get blocked.

With the CancellationToken, the user can define a timeout and handle when the call fails.

Please let me know if anything else is needed.
