### PR TITLE
Add Description attribute to bit and group mask members

### DIFF
--- a/interface/Device.tt
+++ b/interface/Device.tt
@@ -802,6 +802,7 @@ foreach (var bitMask in deviceMetadata.BitMasks)
         /// <summary>
         /// <#= fieldInfo.Description #>
         /// </summary>
+        [Description("<#= fieldInfo.Description #>")]
 <#
         }
 #>

--- a/interface/Device.tt
+++ b/interface/Device.tt
@@ -838,6 +838,7 @@ foreach (var groupMask in deviceMetadata.GroupMasks)
         /// <summary>
         /// <#= memberInfo.Description #>
         /// </summary>
+        [Description("<#= memberInfo.Description #>")]
 <#
         }
 #>


### PR DESCRIPTION
Hi everyone,

For those devices that have bit and group masks with descriptions on each member, we can generate the corresponding Enum's members with a Description attribute besides the documentation comments that is already being written.

This could be helpful to gather and present that descriptive information more easily, especially in UIs.

Please let me know if anything else is needed.

Cheers