### PR TITLE
Rename metadata operator to GetDeviceMetadata

### DIFF
--- a/interface/Device.tt
+++ b/interface/Device.tt
@@ -89,7 +89,7 @@ foreach (var register in deviceRegisters)
     /// describing the <see cref="<#= deviceName #>"/> device registers.
     /// </summary>
     [Description("Returns the contents of the metadata file describing the <#= deviceName #> device registers.")]
-    public partial class GetMetadata : Source<string>
+    public partial class GetDeviceMetadata : Source<string>
     {
         /// <summary>
         /// Returns an observable sequence with the contents of the metadata file


### PR DESCRIPTION
The current name `GetMetadata` is much too vague and disrupts toolbox search patterns, i.e. when typing the keyword "device" nothing will be shown.

We do not include in the generator a provision for obsoleting the previous operator, as this is a decision to make on a package-by-package basis and we do not want to unnecessarily increase the surface area of new interface packages.

Fixes #70 