### PR TITLE
Add operator for logging device data and metadata

### DIFF
--- a/interface/Device.tt
+++ b/interface/Device.tt
@@ -127,24 +127,82 @@ foreach (var register in deviceRegisters)
     }
 
     /// <summary>
-    /// Represents an operator that writes each Harp message in the sequence to a raw binary file
-    /// and the contents of the device metadata file to a separate text file.
+    /// Represents an operator that writes all messages in the sequence to the standard Harp binary format.
     /// </summary>
-    [Description("Writes each Harp message in the sequence to a raw binary file and the contents of the device metadata file to a separate text file.")]
-    public partial class MessageWriter : Bonsai.Harp.MessageWriter
+    [Description("Writes each Harp message in the sequence to raw binary files and the contents of the device metadata file to a separate text file.")]
+    public partial class MessageWriter : Sink<HarpMessage>
     {
+        readonly Bonsai.Harp.MessageWriter writer = new();
+
+        /// <summary>
+        /// Gets or sets the relative or absolute path of the directory on which to save
+        /// the binary data.
+        /// </summary>
+        [Category(nameof(CategoryAttribute.Data))]
+        [Description("The relative or absolute path of the directory on which to save the binary data.")]
+        [Editor("Bonsai.Design.SaveFileNameEditor, Bonsai.Design", DesignTypes.UITypeEditor)]
+        public string Path
+        {
+            get => System.IO.Path.GetDirectoryName(writer.FileName);
+            set => writer.FileName = System.IO.Path.Combine(value, nameof(<#= deviceName #>) + ".bin");
+        }
+
         /// <summary>
         /// Gets or sets the name of the file on which to write the device metadata.
         /// </summary>
-        [Category(nameof(Device.Metadata))]
+        [Category(nameof(CategoryAttribute.Data))]
         [FileNameFilter("YAML Files (*.yml;*.yaml)|*.yml;*.yaml|All Files|*.*")]
         [Editor("Bonsai.Design.SaveFileNameEditor, Bonsai.Design", DesignTypes.UITypeEditor)]
         public string MetadataFileName { get; set; } = "device.yml";
 
+        /// <summary>
+        /// Gets or sets a value indicating whether element writing should be buffered. If <see langword="true"/>,
+        /// the write commands will be queued in memory as fast as possible and will be processed
+        /// by the writer in a different thread. Otherwise, writing will be done in the same
+        /// thread in which notifications arrive.
+        /// </summary>
+        [Description("Indicates whether writing should be buffered.")]
+        public bool Buffered
+        {
+            get => writer.Buffered;
+            set => writer.Buffered = value;
+        }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to overwrite the output file if it already exists.
+        /// </summary>
+        [Description("Indicates whether to overwrite the output file if it already exists.")]
+        public bool Overwrite
+        {
+            get => writer.Overwrite;
+            set => writer.Overwrite = value;
+        }
+
+        /// <summary>
+        /// Gets or sets a value specifying how the message filter will use the matching criteria.
+        /// </summary>
+        [Description("Specifies how the message filter will use the matching criteria.")]
+        public FilterType FilterType
+        {
+            get => writer.FilterType;
+            set => writer.FilterType = value;
+        }
+
+        /// <summary>
+        /// Gets or sets a value specifying the expected message type. If no value is
+        /// specified, all messages will be accepted.
+        /// </summary>
+        [Description("Specifies the expected message type. If no value is specified, all messages will be accepted.")]
+        public MessageType? MessageType
+        {
+            get => writer.MessageType;
+            set => writer.MessageType = value;
+        }
+
         private IObservable<TSource> WriteDeviceMetadata<TSource>(IObservable<TSource> source)
         {
+            var basePath = Path;
             var metadataPath = MetadataFileName;
-            var basePath = System.IO.Path.GetDirectoryName(base.FileName);
             if (string.IsNullOrEmpty(basePath) || string.IsNullOrEmpty(metadataPath))
                 return source;
 
@@ -153,6 +211,12 @@ foreach (var register in deviceRegisters)
 
             return Observable.Create<TSource>(observer =>
             {
+                Bonsai.IO.PathHelper.EnsureDirectory(metadataPath);
+                if (System.IO.File.Exists(metadataPath) && !Overwrite)
+                {
+                    throw new System.IO.IOException(string.Format("The file '{0}' already exists.", metadataPath));
+                }
+
                 System.IO.File.WriteAllText(metadataPath, Device.Metadata);
                 return source.SubscribeSafe(observer);
             });
@@ -169,9 +233,12 @@ foreach (var register in deviceRegisters)
         /// messages to a raw binary file, and the contents of the device metadata file
         /// to a separate text file.
         /// </returns>
-        public new IObservable<HarpMessage> Process(IObservable<HarpMessage> source)
+        public override IObservable<HarpMessage> Process(IObservable<HarpMessage> source)
         {
-            return WriteDeviceMetadata(base.Process(source));
+            return source.Publish(ps => ps.Merge(
+                WriteDeviceMetadata(writer.Process(ps.GroupBy(message => message.Address)))
+                .IgnoreElements()
+                .Cast<HarpMessage>()));
         }
 
         /// <summary>
@@ -190,9 +257,9 @@ foreach (var register in deviceRegisters)
         /// messages in each group to the corresponding file, and the contents of the device
         /// metadata file to a separate text file.
         /// </returns>
-        public new IObservable<IGroupedObservable<int, HarpMessage>> Process(IObservable<IGroupedObservable<int, HarpMessage>> source)
+        public IObservable<IGroupedObservable<int, HarpMessage>> Process(IObservable<IGroupedObservable<int, HarpMessage>> source)
         {
-            return WriteDeviceMetadata(base.Process(source));
+            return WriteDeviceMetadata(writer.Process(source));
         }
 
         /// <summary>
@@ -211,9 +278,9 @@ foreach (var register in deviceRegisters)
         /// messages in each group to the corresponding file, and the contents of the device
         /// metadata file to a separate text file.
         /// </returns>
-        public new IObservable<IGroupedObservable<Type, HarpMessage>> Process(IObservable<IGroupedObservable<Type, HarpMessage>> source)
+        public IObservable<IGroupedObservable<Type, HarpMessage>> Process(IObservable<IGroupedObservable<Type, HarpMessage>> source)
         {
-            return WriteDeviceMetadata(base.Process(source));
+            return WriteDeviceMetadata(writer.Process(source));
         }
     }
 <#

--- a/interface/Device.tt
+++ b/interface/Device.tt
@@ -125,6 +125,97 @@ foreach (var register in deviceRegisters)
             return source.GroupBy(message => Device.RegisterMap[message.Address]);
         }
     }
+
+    /// <summary>
+    /// Represents an operator that writes each Harp message in the sequence to a raw binary file
+    /// and the contents of the device metadata file to a separate text file.
+    /// </summary>
+    [Description("Writes each Harp message in the sequence to a raw binary file and the contents of the device metadata file to a separate text file.")]
+    public partial class MessageWriter : Bonsai.Harp.MessageWriter
+    {
+        /// <summary>
+        /// Gets or sets the name of the file on which to write the device metadata.
+        /// </summary>
+        [Category(nameof(Device.Metadata))]
+        [FileNameFilter("YAML Files (*.yml;*.yaml)|*.yml;*.yaml|All Files|*.*")]
+        [Editor("Bonsai.Design.SaveFileNameEditor, Bonsai.Design", DesignTypes.UITypeEditor)]
+        public string MetadataFileName { get; set; } = "device.yml";
+
+        private IObservable<TSource> WriteDeviceMetadata<TSource>(IObservable<TSource> source)
+        {
+            var metadataPath = MetadataFileName;
+            var basePath = System.IO.Path.GetDirectoryName(base.FileName);
+            if (string.IsNullOrEmpty(basePath) || string.IsNullOrEmpty(metadataPath))
+                return source;
+
+            if (!System.IO.Path.IsPathRooted(metadataPath))
+                metadataPath = System.IO.Path.Combine(basePath, metadataPath);
+
+            return Observable.Create<TSource>(observer =>
+            {
+                System.IO.File.WriteAllText(metadataPath, Device.Metadata);
+                return source.SubscribeSafe(observer);
+            });
+        }
+
+        /// <summary>
+        /// Writes each Harp message in the sequence to the specified binary file, and the
+        /// contents of the device metadata file to a separate text file.
+        /// </summary>
+        /// <param name="source">The sequence of messages to write to the file.</param>
+        /// <returns>
+        /// An observable sequence that is identical to the <paramref name="source"/>
+        /// sequence but where there is an additional side effect of writing the
+        /// messages to a raw binary file, and the contents of the device metadata file
+        /// to a separate text file.
+        /// </returns>
+        public new IObservable<HarpMessage> Process(IObservable<HarpMessage> source)
+        {
+            return WriteDeviceMetadata(base.Process(source));
+        }
+
+        /// <summary>
+        /// Writes each Harp message in the sequence of observable groups to the
+        /// corresponding binary file, where the name of each file is generated from
+        /// the common group register address. The contents of the device metadata file are
+        /// written to a separate text file.
+        /// </summary>
+        /// <param name="source">
+        /// A sequence of observable groups, each of which corresponds to a unique register
+        /// address.
+        /// </param>
+        /// <returns>
+        /// An observable sequence that is identical to the <paramref name="source"/>
+        /// sequence but where there is an additional side effect of writing the Harp
+        /// messages in each group to the corresponding file, and the contents of the device
+        /// metadata file to a separate text file.
+        /// </returns>
+        public new IObservable<IGroupedObservable<int, HarpMessage>> Process(IObservable<IGroupedObservable<int, HarpMessage>> source)
+        {
+            return WriteDeviceMetadata(base.Process(source));
+        }
+
+        /// <summary>
+        /// Writes each Harp message in the sequence of observable groups to the
+        /// corresponding binary file, where the name of each file is generated from
+        /// the common group register name. The contents of the device metadata file are
+        /// written to a separate text file.
+        /// </summary>
+        /// <param name="source">
+        /// A sequence of observable groups, each of which corresponds to a unique register
+        /// type.
+        /// </param>
+        /// <returns>
+        /// An observable sequence that is identical to the <paramref name="source"/>
+        /// sequence but where there is an additional side effect of writing the Harp
+        /// messages in each group to the corresponding file, and the contents of the device
+        /// metadata file to a separate text file.
+        /// </returns>
+        public new IObservable<IGroupedObservable<Type, HarpMessage>> Process(IObservable<IGroupedObservable<Type, HarpMessage>> source)
+        {
+            return WriteDeviceMetadata(base.Process(source));
+        }
+    }
 <#
 if (deviceRegisters.Count > 0)
 {

--- a/interface/Device.tt
+++ b/interface/Device.tt
@@ -127,33 +127,26 @@ foreach (var register in deviceRegisters)
     }
 
     /// <summary>
-    /// Represents an operator that writes all messages in the sequence to the standard Harp binary format.
+    /// Represents an operator that writes the sequence of <see cref="<#= deviceName #>"/>" messages
+    /// to the standard Harp storage format.
     /// </summary>
-    [Description("Writes each Harp message in the sequence to raw binary files and the contents of the device metadata file to a separate text file.")]
-    public partial class MessageWriter : Sink<HarpMessage>
+    [Description("Writes the sequence of <#= deviceName #> messages to the standard Harp storage format.")]
+    public partial class DeviceDataWriter : Sink<HarpMessage>
     {
+        const string BinaryExtension = ".bin";
+        const string MetadataFileName = "device.yml";
         readonly Bonsai.Harp.MessageWriter writer = new();
 
         /// <summary>
-        /// Gets or sets the relative or absolute path of the directory on which to save
-        /// the binary data.
+        /// Gets or sets the relative or absolute path on which to save the message data.
         /// </summary>
-        [Category(nameof(CategoryAttribute.Data))]
-        [Description("The relative or absolute path of the directory on which to save the binary data.")]
+        [Description("The relative or absolute path of the directory on which to save the message data.")]
         [Editor("Bonsai.Design.SaveFileNameEditor, Bonsai.Design", DesignTypes.UITypeEditor)]
         public string Path
         {
             get => System.IO.Path.GetDirectoryName(writer.FileName);
-            set => writer.FileName = System.IO.Path.Combine(value, nameof(<#= deviceName #>) + ".bin");
+            set => writer.FileName = System.IO.Path.Combine(value, nameof(<#= deviceName #>) + BinaryExtension);
         }
-
-        /// <summary>
-        /// Gets or sets the name of the file on which to write the device metadata.
-        /// </summary>
-        [Category(nameof(CategoryAttribute.Data))]
-        [FileNameFilter("YAML Files (*.yml;*.yaml)|*.yml;*.yaml|All Files|*.*")]
-        [Editor("Bonsai.Design.SaveFileNameEditor, Bonsai.Design", DesignTypes.UITypeEditor)]
-        public string MetadataFileName { get; set; } = "device.yml";
 
         /// <summary>
         /// Gets or sets a value indicating whether element writing should be buffered. If <see langword="true"/>,
@@ -202,13 +195,10 @@ foreach (var register in deviceRegisters)
         private IObservable<TSource> WriteDeviceMetadata<TSource>(IObservable<TSource> source)
         {
             var basePath = Path;
-            var metadataPath = MetadataFileName;
-            if (string.IsNullOrEmpty(basePath) || string.IsNullOrEmpty(metadataPath))
+            if (string.IsNullOrEmpty(basePath))
                 return source;
 
-            if (!System.IO.Path.IsPathRooted(metadataPath))
-                metadataPath = System.IO.Path.Combine(basePath, metadataPath);
-
+            var metadataPath = System.IO.Path.Combine(basePath, MetadataFileName);
             return Observable.Create<TSource>(observer =>
             {
                 Bonsai.IO.PathHelper.EnsureDirectory(metadataPath);

--- a/interface/Device.tt
+++ b/interface/Device.tt
@@ -131,11 +131,13 @@ foreach (var register in deviceRegisters)
     /// to the standard Harp storage format.
     /// </summary>
     [Description("Writes the sequence of <#= deviceName #> messages to the standard Harp storage format.")]
-    public partial class DeviceDataWriter : Sink<HarpMessage>
+    public partial class DeviceDataWriter : Sink<HarpMessage>, INamedElement
     {
         const string BinaryExtension = ".bin";
         const string MetadataFileName = "device.yml";
         readonly Bonsai.Harp.MessageWriter writer = new();
+
+        string INamedElement.Name => nameof(<#= deviceName #>) + "DataWriter";
 
         /// <summary>
         /// Gets or sets the relative or absolute path on which to save the message data.

--- a/interface/Harp.Generators.csproj
+++ b/interface/Harp.Generators.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <VersionPrefix>0.3.0</VersionPrefix>
+    <VersionPrefix>0.3.1</VersionPrefix>
     <VersionSuffix></VersionSuffix>
     <PackageId>Harp.Generators</PackageId>
     <Title>Harp Generators</Title>


### PR DESCRIPTION
For compliance with the Harp logging standard (https://github.com/harp-tech/protocol/issues/41) we require the device metadata to be saved next to the data to allow building automatic data readers.

Here we introduce a per-device variant of the `MessageWriter` operator called `DeviceDataWriter` which saves the device metadata as a subscription side-effect and ensures all registers are demuxed and named correctly when stored into the specified target path.