### PR TITLE
Avoid disabling dependencies for generator package

### DIFF
--- a/interface/Harp.Generators.csproj
+++ b/interface/Harp.Generators.csproj
@@ -3,11 +3,13 @@
   <PropertyGroup>
     <Description>Provides source generators for Harp device firmware and software interface.</Description>
     <PackageTags>Harp Device Firmware Interface Generators</PackageTags>
-    <SuppressDependenciesWhenPacking>true</SuppressDependenciesWhenPacking>
     <TargetFramework>netstandard2.0</TargetFramework>
     <IncludeContentInPack>true</IncludeContentInPack>
     <IncludeBuildOutput>false</IncludeBuildOutput>
     <ContentTargetFolders>contentFiles</ContentTargetFolders>
+
+    <!-- Disable NU5128 since this package will be used for content only -->
+    <NoWarn>$(NoWarn);NU5128</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Although the package is used for its contents only, the T4 generator does require installation of the declared package references, as they are imported inside the T4 template code.