### PR TITLE
Make Path the default property of DeviceDataWriter

### DIFF
--- a/interface/Device.tt
+++ b/interface/Device.tt
@@ -130,6 +130,7 @@ foreach (var register in deviceRegisters)
     /// Represents an operator that writes the sequence of <see cref="<#= deviceName #>"/>" messages
     /// to the standard Harp storage format.
     /// </summary>
+    [DefaultProperty(nameof(Path))]
     [Description("Writes the sequence of <#= deviceName #> messages to the standard Harp storage format.")]
     public partial class DeviceDataWriter : Sink<HarpMessage>, INamedElement
     {


### PR DESCRIPTION
To enable specifying the storage path directly in the toolbox, or by double-clicking the node in the visual editor, we declare `Path` as the default property of generated `DeviceDataWriter` classes.