### PR TITLE
Implement missing interface methods in firmware generator

### DIFF
--- a/build/Version.props
+++ b/build/Version.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <VersionPrefix>0.4.0</VersionPrefix>
+    <VersionPrefix>0.4.1</VersionPrefix>
     <VersionSuffix></VersionSuffix>
   </PropertyGroup>
 </Project>

--- a/interface/IO.tt
+++ b/interface/IO.tt
@@ -129,7 +129,7 @@ class PortPinInfoTypeConverter : IYamlTypeConverter
         return type == typeof(PortPinInfo);
     }
 
-    public object ReadYaml(IParser parser, Type type)
+    public object ReadYaml(IParser parser, Type type, ObjectDeserializer rootDeserializer)
     {
         var portPin = Deserializer.Deserialize<Dictionary<object, object>>(parser);
         if (portPin.TryGetValue(DirectionProperty, out object value))
@@ -155,7 +155,7 @@ class PortPinInfoTypeConverter : IYamlTypeConverter
         throw new YamlException($"Required property '{DirectionProperty}' not found when deserializing type '{typeof(PortPinInfo)}'.");
     }
 
-    public void WriteYaml(IEmitter emitter, object value, Type type)
+    public void WriteYaml(IEmitter emitter, object value, Type type, ObjectSerializer serializer)
     {
         throw new NotImplementedException();
     }

--- a/interface/IO.tt
+++ b/interface/IO.tt
@@ -188,5 +188,10 @@ class FirmwareNamingConvention : INamingConvention
         });
         return value.ToUpperInvariant();
     }
+
+    public string Reverse(string value)
+    {
+        throw new NotImplementedException();
+    }
 }
 #>


### PR DESCRIPTION
This PR completes the YamlDotNet update on the firmware generation side, by adding missing method parameters and method signatures which have changed in the latest version.

Fixes #83 