### PR TITLE
Add template for Python interface generation

### DIFF
--- a/interface/harpdevice.tt
+++ b/interface/harpdevice.tt
@@ -1,0 +1,315 @@
+<#@ template debug="false" hostspecific="true" language="C#" #>
+<#@ parameter name="Namespace" type="string" #>
+<#@ parameter name="MetadataPath" type="string" #>
+<#@ assembly name="System.Core" #>
+<#@ import namespace="System.IO" #>
+<#@ import namespace="System.Linq" #>
+<#@ import namespace="System.Text" #>
+<#@ import namespace="System.Collections.Generic" #>
+<#@ import namespace="System.Globalization" #>
+<#@ import namespace="System.Text.RegularExpressions" #>
+<#@ include file="Interface.tt" #><##>
+<#@ output extension=".py" #>
+<#
+var deviceMetadata = TemplateHelper.ReadDeviceMetadata(MetadataPath);
+var publicRegisters = deviceMetadata.Registers.Where(register => register.Value.Visibility == RegisterVisibility.Public).ToList();
+var deviceRegisters = deviceMetadata.Registers;
+var deviceName = deviceMetadata.Device;
+#>
+from dataclasses import dataclass
+from enum import Enum, IntFlag
+
+from harp.communication import Device
+from harp.protocol import MessageType, PayloadType
+from harp.protocol.exceptions import HarpReadException, HarpWriteException
+from harp.protocol.messages import HarpMessage
+
+<#
+// Order is important for acronyms, so longer acronyms should be listed first
+string[] AcronymExceptions = new[] { "DIO", "DI", "DO", "IR", "USB" };
+// Regex for units: ms, hz, v (case-insensitive)
+Regex UnitRegex = new Regex(@"^\d+(ms|hz|v)", RegexOptions.IgnoreCase | RegexOptions.Compiled);
+
+string ToSnakeCase(string name, bool allCaps = false)
+{
+    if (string.IsNullOrEmpty(name)) return name;
+    var sb = new System.Text.StringBuilder();
+    int i = 0;
+    while (i < name.Length)
+    {
+        bool matched = false;
+        // Acronym exceptions
+        foreach (var acronym in AcronymExceptions)
+        {
+            if (i + acronym.Length <= name.Length &&
+                string.Compare(name, i, acronym, 0, acronym.Length, ignoreCase: false, culture: null) == 0)
+            {
+                if (i > 0 && sb[sb.Length - 1] != '_')
+                    sb.Append('_');
+                sb.Append(acronym.ToLowerInvariant());
+                i += acronym.Length;
+                matched = true;
+                break;
+            }
+        }
+        if (matched) continue;
+
+        // Digits+unit pattern (e.g., 5V, 10300Hz, 1Ms)
+        var unitMatch = UnitRegex.Match(name.Substring(i));
+        if (unitMatch.Success)
+        {
+            int matchLen = unitMatch.Length;
+            int nextIdx = i + matchLen;
+            // Only treat as a unit if next char does not exist or is uppercase
+            if (nextIdx >= name.Length || char.IsUpper(name[nextIdx]))
+            {
+                if (i > 0 && sb[sb.Length - 1] != '_')
+                    sb.Append('_');
+                sb.Append(name.Substring(i, matchLen).ToLowerInvariant());
+                i += matchLen;
+                // If next char is uppercase, treat as word boundary
+                if (nextIdx < name.Length && char.IsUpper(name[nextIdx]))
+                    sb.Append('_');
+                continue;
+            }
+        }
+
+        // Digits: keep with previous word, and if next char is uppercase, treat as word boundary
+        if (char.IsDigit(name[i]))
+        {
+            sb.Append(name[i]);
+            int nextIdx = i + 1;
+            if (nextIdx < name.Length && char.IsUpper(name[nextIdx]))
+                sb.Append('_');
+            i++;
+            continue;
+        }
+
+        // Default PascalCase to snake_case
+        var c = name[i];
+        if (char.IsUpper(c) && i > 0 && sb[sb.Length - 1] != '_')
+            sb.Append('_');
+        sb.Append(char.ToLowerInvariant(c));
+        i++;
+    }
+    var result = sb.ToString();
+    return allCaps ? result.ToUpperInvariant() : result;
+}
+
+// Helper for type conversion
+Func<string, string> pyType = t =>
+{
+    switch (t)
+    {
+        case "byte":
+        case "sbyte":
+        case "ushort":
+        case "short":
+        case "uint":
+        case "int":
+        case "ulong":
+        case "long":
+            return "int";
+        case "float":
+            return "float";
+        case "ArraySegment<byte>":
+        case "byte[]":
+            return "bytes";
+        case "short[]":
+        case "ushort[]":
+        case "uint[]":
+        case "int[]":
+        case "long[]":
+            return "list[int]";
+        case "EnableFlag":
+            return "bool";
+        default:
+            return t; // fallback
+    }
+};
+#>
+<# // Payload dataclasses
+var payloadTypes = new HashSet<string>();
+foreach (var registerMetadata in deviceRegisters)
+{
+    var register = registerMetadata.Value;
+    if (register.PayloadSpec == null) continue;
+    var interfaceType = TemplateHelper.GetInterfaceType(registerMetadata.Key, register);
+    if (!payloadTypes.Add(interfaceType)) continue;
+#>
+
+@dataclass
+class <#= interfaceType #>:
+<# 
+    foreach (var member in register.PayloadSpec)
+    {
+        var memberType = TemplateHelper.GetInterfaceType(member.Value, register.Type);
+        if (!string.IsNullOrEmpty(member.Value.Description))
+        {
+#>
+        # <#= member.Value.Description #>
+<#      }
+#>
+    <#= member.Key #>: <#= pyType(memberType) #>
+<# 
+    }
+}
+#>
+<# // BitMask enums
+foreach (var bitMask in deviceMetadata.BitMasks)
+{
+    var mask = bitMask.Value;
+#>
+
+
+class <#= bitMask.Key #>(IntFlag):
+    """
+    <#= mask.Description #>
+
+    Attributes
+    ----------
+<# 
+    foreach (var bitField in mask.Bits)
+    {
+        var fieldInfo = bitField.Value;
+#>
+    <#= ToSnakeCase(bitField.Key, allCaps:true) #> : int
+        <#= string.IsNullOrEmpty(fieldInfo.Description) ? "_No description currently available_" : fieldInfo.Description #>
+<#  } #>
+    """
+
+<#   
+    // Add a NONE value if there are no bits set
+    var bitCount = mask.Bits.Count;
+    if (!mask.Bits.Values.Any(fieldInfo => fieldInfo.Value == 0))
+    {
+#>
+    NONE = 0x0
+<#
+    }
+    foreach (var bitField in mask.Bits)
+    {
+        var fieldInfo = bitField.Value;
+#>
+    <#= ToSnakeCase(bitField.Key, allCaps:true) #> = 0x<#= fieldInfo.Value.ToString("X") #>
+<#
+    }
+}
+#>
+<# 
+// GroupMask enums
+foreach (var groupMask in deviceMetadata.GroupMasks)
+{
+    var mask = groupMask.Value;
+#>
+
+
+class <#= groupMask.Key #>(Enum):
+    """
+    <#= mask.Description #>
+
+    Attributes
+    ----------
+<# 
+    foreach (var member in mask.Values)
+    {
+        var memberInfo = member.Value;
+#>
+    <#= ToSnakeCase(member.Key, allCaps:true) #> : int
+        <#= string.IsNullOrEmpty(memberInfo.Description) ? "_No description currently available_" : memberInfo.Description #>
+<#  } #>
+    """
+
+<# 
+    foreach (var member in mask.Values)
+    {
+        var memberInfo = member.Value;
+#>
+    <#= ToSnakeCase(member.Key, allCaps:true) #> = <#= memberInfo.Value #>
+<#
+    }
+}
+#>
+
+
+class <#= deviceName #>Registers(Enum):
+    """Enum for all available registers in the <#= deviceName #> device.
+
+    Attributes
+    ----------
+<# 
+    foreach (var registerMetadata in publicRegisters)
+    {
+        var regName = registerMetadata.Key;
+        var reg = registerMetadata.Value;
+        var interfaceType = TemplateHelper.GetInterfaceType(registerMetadata.Key, registerMetadata.Value);
+#>
+    <#= ToSnakeCase(regName, allCaps:true) #> : int
+        <#= reg.Description ?? "Register address for the " + regName + " register." #>
+<# } #>
+    """
+<#
+    foreach (var registerMetadata in publicRegisters)
+    {
+        var regName = registerMetadata.Key;
+        var reg = registerMetadata.Value;
+        var address = reg.Address;
+#>
+    <#= ToSnakeCase(regName, allCaps:true) #> = <#= address #>
+<#
+    }
+#>
+
+
+class <#= deviceName #>(Device):
+    """
+    <#= deviceName #> class for controlling the device.
+    """
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        # connect and load already happened in the base class
+        # verify that WHO_AM_I matches the expected value
+        if self.WHO_AM_I != <#= deviceMetadata.WhoAmI #>:
+            self.disconnect()
+            raise Exception(f"WHO_AM_I mismatch: expected {<#= deviceMetadata.WhoAmI #>}, got {self.WHO_AM_I}")
+
+<# foreach (var registerMetadata in publicRegisters) {
+    var regName = registerMetadata.Key;
+    var reg = registerMetadata.Value;
+    //var interfaceType = TemplateHelper.GetInterfaceType(reg.Type, reg.Length);
+    var interfaceType = TemplateHelper.GetInterfaceType(registerMetadata.Key, registerMetadata.Value);
+#>
+    def read_<#= ToSnakeCase(regName) #>(self) -> <#= pyType(interfaceType) #>:
+        """
+        Reads the contents of the <#= regName #> register.
+
+        Returns
+        -------
+        <#= pyType(interfaceType) #>
+            Value read from the <#= regName #> register.
+        """
+        address = <#= reg.Address #>
+        reply = self.send(HarpMessage.create(MessageType.READ, address, PayloadType.<#= reg.Type #>))
+        if reply.is_error:
+            raise HarpReadException("<#= regName #>", reply.error_message)
+
+        return reply.payload
+
+<# if ((reg.Access & RegisterAccess.Write) != 0) { #>
+    def write_<#= ToSnakeCase(regName) #>(self, value: <#= pyType(interfaceType) #>):
+        """
+        Writes a value to the <#= regName #> register.
+
+        Parameters
+        ----------
+        value : <#= pyType(interfaceType) #>
+            Value to write to the <#= regName #> register.
+        """
+        address = <#= reg.Address #>
+        reply = self.send(HarpMessage.create(MessageType.WRITE, address, PayloadType.<#= reg.Type #>, value))
+        if reply.is_error:
+            raise HarpWriteException("<#= regName #>", reply.error_message)
+<# } #>
+<# } #>

--- a/interface/harpdevice.tt
+++ b/interface/harpdevice.tt
@@ -15,15 +15,16 @@ var deviceMetadata = TemplateHelper.ReadDeviceMetadata(MetadataPath);
 var publicRegisters = deviceMetadata.Registers.Where(register => register.Value.Visibility == RegisterVisibility.Public).ToList();
 var deviceRegisters = deviceMetadata.Registers;
 var deviceName = deviceMetadata.Device;
+var bitmaskTypes = new HashSet<string>(deviceMetadata.BitMasks.Keys);
+var groupmaskTypes = new HashSet<string>(deviceMetadata.GroupMasks.Keys);
 #>
 from dataclasses import dataclass
 from enum import IntEnum, IntFlag
 
-from harp.communication import Device
 from harp.protocol import MessageType, PayloadType
 from harp.protocol.exceptions import HarpReadException, HarpWriteException
-from harp.protocol.messages import HarpMessage
-
+from harp.protocol.messages import HarpMessage, ReplyHarpMessage
+from harp.serial import Device
 <#
 // Order is important for acronyms, so longer acronyms should be listed first
 string[] AcronymExceptions = new[] { "DIO", "DI", "DO", "IR", "USB" };
@@ -248,6 +249,7 @@ class <#= deviceName #>Registers(IntEnum):
         <#= reg.Description ?? "Register address for the " + regName + " register." #>
 <# } #>
     """
+
 <#
     foreach (var registerMetadata in publicRegisters)
     {
@@ -278,8 +280,10 @@ class <#= deviceName #>(Device):
 <# foreach (var registerMetadata in publicRegisters) {
     var regName = registerMetadata.Key;
     var reg = registerMetadata.Value;
-    //var interfaceType = TemplateHelper.GetInterfaceType(reg.Type, reg.Length);
     var interfaceType = TemplateHelper.GetInterfaceType(registerMetadata.Key, registerMetadata.Value);
+    var hasPayloadSpec = reg.PayloadSpec != null;
+    var isBitmask = bitmaskTypes.Contains(interfaceType);
+    var isGroupmask = groupmaskTypes.Contains(interfaceType);
 #>
     def read_<#= ToSnakeCase(regName) #>(self) -> <#= pyType(interfaceType) #>:
         """
@@ -295,7 +299,36 @@ class <#= deviceName #>(Device):
         if reply.is_error:
             raise HarpReadException("<#= regName #>", reply.error_message)
 
+<#  if (hasPayloadSpec)
+    {
+#>
+        # Map payload (list/array) to dataclass fields by offset
+        payload = reply.payload
+        return <#= interfaceType #>(
+<#  
+        var memberCount = reg.PayloadSpec.Count;
+        var memberIndex = 0;
+        foreach (var member in reg.PayloadSpec) {
+            var offset = member.Value.Offset ?? memberIndex;
+#>            <#= member.Key #>=payload[<#= offset #>]<#= ++memberIndex < memberCount ? "," : "" #>
+<#
+        }
+#>
+        )
+<#  }
+    else if (isBitmask || isGroupmask)
+    {
+#>
+        return <#= interfaceType #>(reply.payload)
+<#  }
+    else
+    {
+#>
+        # Directly return the payload as it is a primitive type
         return reply.payload
+<# 
+    }
+#>
 
 <# if ((reg.Access & RegisterAccess.Write) != 0) { #>
     def write_<#= ToSnakeCase(regName) #>(self, value: <#= pyType(interfaceType) #>):

--- a/interface/harpdevice.tt
+++ b/interface/harpdevice.tt
@@ -22,8 +22,8 @@ from dataclasses import dataclass
 from enum import IntEnum, IntFlag
 
 from harp.protocol import MessageType, PayloadType
-from harp.protocol.exceptions import HarpReadException, HarpWriteException
-from harp.protocol.messages import HarpMessage, ReplyHarpMessage
+from harp.protocol.exceptions import HarpException, HarpReadException, HarpWriteException
+from harp.protocol.messages import HarpMessage
 from harp.serial import Device
 <#
 // Order is important for acronyms, so longer acronyms should be listed first
@@ -275,7 +275,7 @@ class <#= deviceName #>(Device):
         # verify that WHO_AM_I matches the expected value
         if self.WHO_AM_I != <#= deviceMetadata.WhoAmI #>:
             self.disconnect()
-            raise Exception(f"WHO_AM_I mismatch: expected {<#= deviceMetadata.WhoAmI #>}, got {self.WHO_AM_I}")
+            raise HarpException(f"WHO_AM_I mismatch: expected {<#= deviceMetadata.WhoAmI #>}, got {self.WHO_AM_I}")
 
 <# foreach (var registerMetadata in publicRegisters) {
     var regName = registerMetadata.Key;
@@ -285,53 +285,56 @@ class <#= deviceName #>(Device):
     var isBitmask = bitmaskTypes.Contains(interfaceType);
     var isGroupmask = groupmaskTypes.Contains(interfaceType);
 #>
-    def read_<#= ToSnakeCase(regName) #>(self) -> <#= pyType(interfaceType) #>:
+    def read_<#= ToSnakeCase(regName) #>(self) -> <#= pyType(interfaceType) #> | None:
         """
         Reads the contents of the <#= regName #> register.
 
         Returns
         -------
-        <#= pyType(interfaceType) #>
+        <#= pyType(interfaceType) #> | None
             Value read from the <#= regName #> register.
         """
         address = <#= deviceName #>Registers.<#= ToSnakeCase(regName, allCaps:true) #>
-        reply = self.send(HarpMessage.create(MessageType.READ, address, PayloadType.<#= reg.Type #>))
+        reply = self.send(HarpMessage(MessageType.READ, PayloadType.<#= reg.Type #>, address))
         if reply is not None and reply.is_error:
-            raise HarpReadException("<#= regName #>")
+            raise HarpReadException("<#= deviceName #>Registers.<#= ToSnakeCase(regName, allCaps:true) #>", reply)
 
+        if reply is not None:
 <#  if (hasPayloadSpec)
     {
 #>
-        # Map payload (list/array) to dataclass fields by offset
-        payload = reply.payload
-        return <#= interfaceType #>(
+            # Map payload (list/array) to dataclass fields by offset
+            payload = reply.payload
+            return <#= interfaceType #>(
 <#  
         var memberCount = reg.PayloadSpec.Count;
         var memberIndex = 0;
         foreach (var member in reg.PayloadSpec) {
             var offset = member.Value.Offset ?? memberIndex;
-#>            <#= member.Key #>=payload[<#= offset #>]<#= ++memberIndex < memberCount ? "," : "" #>
+#>
+                <#= member.Key #>=payload[<#= offset #>]<#= ++memberIndex < memberCount ? "," : "" #>
 <#
         }
 #>
-        )
+            )
 <#  }
     else if (isBitmask || isGroupmask)
     {
 #>
-        return <#= interfaceType #>(reply.payload)
+            return <#= interfaceType #>(reply.payload)
 <#  }
     else
     {
 #>
-        # Directly return the payload as it is a primitive type
-        return reply.payload
+            # Directly return the payload as it is a primitive type
+            return reply.payload
 <# 
     }
-#>
+#>      
+        return None
 
 <# if ((reg.Access & RegisterAccess.Write) != 0) { #>
-    def write_<#= ToSnakeCase(regName) #>(self, value: <#= pyType(interfaceType) #>) -> ReplyHarpMessage | None:
+    def write_<#= ToSnakeCase(regName) #>(self, value: <#= pyType(interfaceType) #>) -> HarpMessage | None:
         """
         Writes a value to the <#= regName #> register.
 
@@ -341,9 +344,9 @@ class <#= deviceName #>(Device):
             Value to write to the <#= regName #> register.
         """
         address = <#= deviceName #>Registers.<#= ToSnakeCase(regName, allCaps:true) #>
-        reply = self.send(HarpMessage.create(MessageType.WRITE, address, PayloadType.<#= reg.Type #>, value))
+        reply = self.send(HarpMessage(MessageType.WRITE, PayloadType.<#= reg.Type #>, address, value))
         if reply is not None and reply.is_error:
-            raise HarpWriteException("<#= regName #>")
+            raise HarpWriteException("<#= deviceName #>Registers.<#= ToSnakeCase(regName, allCaps:true) #>", reply)
 
         return reply
 

--- a/interface/harpdevice.tt
+++ b/interface/harpdevice.tt
@@ -17,7 +17,7 @@ var deviceRegisters = deviceMetadata.Registers;
 var deviceName = deviceMetadata.Device;
 #>
 from dataclasses import dataclass
-from enum import Enum, IntFlag
+from enum import IntEnum, IntFlag
 
 from harp.communication import Device
 from harp.protocol import MessageType, PayloadType
@@ -204,7 +204,7 @@ foreach (var groupMask in deviceMetadata.GroupMasks)
 #>
 
 
-class <#= groupMask.Key #>(Enum):
+class <#= groupMask.Key #>(IntEnum):
     """
     <#= mask.Description #>
 
@@ -232,7 +232,7 @@ class <#= groupMask.Key #>(Enum):
 #>
 
 
-class <#= deviceName #>Registers(Enum):
+class <#= deviceName #>Registers(IntEnum):
     """Enum for all available registers in the <#= deviceName #> device.
 
     Attributes

--- a/interface/harpdevice.tt
+++ b/interface/harpdevice.tt
@@ -295,7 +295,7 @@ class <#= deviceName #>(Device):
             Value read from the <#= regName #> register.
         """
         address = <#= deviceName #>Registers.<#= ToSnakeCase(regName, allCaps:true) #>
-        reply = self.send(HarpMessage(MessageType.READ, PayloadType.<#= reg.Type #>, address))
+        reply = self.send(HarpMessage(MessageType.READ, PayloadType.<#= reg.Type.ToString().ToUpperInvariant() #>, address))
         if reply is not None and reply.is_error:
             raise HarpReadException("<#= deviceName #>Registers.<#= ToSnakeCase(regName, allCaps:true) #>", reply)
 
@@ -344,7 +344,7 @@ class <#= deviceName #>(Device):
             Value to write to the <#= regName #> register.
         """
         address = <#= deviceName #>Registers.<#= ToSnakeCase(regName, allCaps:true) #>
-        reply = self.send(HarpMessage(MessageType.WRITE, PayloadType.<#= reg.Type #>, address, value))
+        reply = self.send(HarpMessage(MessageType.WRITE, PayloadType.<#= reg.Type.ToString().ToUpperInvariant() #>, address, value))
         if reply is not None and reply.is_error:
             raise HarpWriteException("<#= deviceName #>Registers.<#= ToSnakeCase(regName, allCaps:true) #>", reply)
 

--- a/interface/harpdevice.tt
+++ b/interface/harpdevice.tt
@@ -294,10 +294,10 @@ class <#= deviceName #>(Device):
         <#= pyType(interfaceType) #>
             Value read from the <#= regName #> register.
         """
-        address = <#= reg.Address #>
+        address = <#= deviceName #>Registers.<#= ToSnakeCase(regName, allCaps:true) #>
         reply = self.send(HarpMessage.create(MessageType.READ, address, PayloadType.<#= reg.Type #>))
-        if reply.is_error:
-            raise HarpReadException("<#= regName #>", reply.error_message)
+        if reply is not None and reply.is_error:
+            raise HarpReadException("<#= regName #>")
 
 <#  if (hasPayloadSpec)
     {
@@ -331,7 +331,7 @@ class <#= deviceName #>(Device):
 #>
 
 <# if ((reg.Access & RegisterAccess.Write) != 0) { #>
-    def write_<#= ToSnakeCase(regName) #>(self, value: <#= pyType(interfaceType) #>):
+    def write_<#= ToSnakeCase(regName) #>(self, value: <#= pyType(interfaceType) #>) -> ReplyHarpMessage | None:
         """
         Writes a value to the <#= regName #> register.
 
@@ -340,9 +340,12 @@ class <#= deviceName #>(Device):
         value : <#= pyType(interfaceType) #>
             Value to write to the <#= regName #> register.
         """
-        address = <#= reg.Address #>
+        address = <#= deviceName #>Registers.<#= ToSnakeCase(regName, allCaps:true) #>
         reply = self.send(HarpMessage.create(MessageType.WRITE, address, PayloadType.<#= reg.Type #>, value))
-        if reply.is_error:
-            raise HarpWriteException("<#= regName #>", reply.error_message)
+        if reply is not None and reply.is_error:
+            raise HarpWriteException("<#= regName #>")
+
+        return reply
+
 <# } #>
 <# } #>

--- a/interface/harpdevice.tt
+++ b/interface/harpdevice.tt
@@ -139,6 +139,7 @@ foreach (var registerMetadata in deviceRegisters)
     if (!payloadTypes.Add(interfaceType)) continue;
 #>
 
+
 @dataclass
 class <#= interfaceType #>:
 <# 
@@ -330,7 +331,7 @@ class <#= deviceName #>(Device):
             return reply.payload
 <# 
     }
-#>      
+#>
         return None
 
 <# if ((reg.Access & RegisterAccess.Write) != 0) { #>

--- a/template/Bonsai.DeviceTemplate/.template.config/template.json
+++ b/template/Bonsai.DeviceTemplate/.template.config/template.json
@@ -27,6 +27,41 @@
             "valueTransform": "identity",
             "fileRename": "DeviceTemplate"
         },
+        "projectNameShort": {
+            "type": "derived",
+            "valueSource": "projectName",
+            "valueTransform": "valueAfterLastDot",
+            "replaces": "$projectnameshort$"
+        },
+        "projectNameLower": {
+            "type": "generated",
+            "generator": "casing",
+            "parameters": {
+                "source": "name",
+                "toLower": true
+            },
+            "replaces": "$projectnamelower$"
+        },
+        "pythonProjectName": {
+            "type": "derived",
+            "valueSource": "projectNameLower",
+            "valueTransform": "replace",
+            "replaces": "$pythonprojectname$",
+            "fileRename": "devicetemplate"
+        },
+        "pythonModuleName": {
+            "type": "derived",
+            "valueSource": "pythonProjectName",
+            "valueTransform": "replaceDotsWithUnderscores",
+            "replaces": "$pythonmodulename$"
+        },
+        "pythonModuleNameShort": {
+            "type": "derived",
+            "valueSource": "projectNameLower",
+            "valueTransform": "valueAfterLastDot",
+            "replaces": "$pythonmodulenameshort$",
+            "fileRename": "moduletemplate"
+        },
         "projectTitle": {
             "type": "derived",
             "valueSource": "name",
@@ -103,6 +138,11 @@
             "identifier": "replace",
             "pattern": "\\.",
             "replacement": " "
+        },
+        "replaceDotsWithUnderscores": {
+            "identifier": "replace",
+            "pattern": "\\.",
+            "replacement": "_"
         }
     },
     "sourceName": "$projectname$",

--- a/template/Bonsai.DeviceTemplate/Generators/Generators.csproj
+++ b/template/Bonsai.DeviceTemplate/Generators/Generators.csproj
@@ -12,6 +12,7 @@
   </PropertyGroup>
   <PropertyGroup>
     <InterfacePath>..\Interface\$projectname$</InterfacePath>
+    <PythonInterfacePath>..\PythonInterface\$pythonprojectname$</PythonInterfacePath>
     <FirmwarePath>..\Firmware\$projectname$</FirmwarePath>
   </PropertyGroup>
   <ItemGroup>
@@ -20,13 +21,25 @@
   <Target Name="TextTransform" BeforeTargets="AfterBuild">
     <PropertyGroup>
       <InterfaceFlags>-p:MetadataPath=$(DeviceMetadata) -p:Namespace=$(RootNamespace) -P=$(TargetDir)</InterfaceFlags>
+      <PythonInterfaceFlags>-p:MetadataPath=$(DeviceMetadata) -p:Namespace=$(RootNamespace) -P=$(TargetDir)</PythonInterfaceFlags>
       <FirmwareFlags>-p:RegisterMetadataPath=$(DeviceMetadata) -p:IOMetadataPath=$(IOMetadata) -P=$(TargetDir)</FirmwareFlags>
     </PropertyGroup>
+    <ItemGroup>
+      <TextTemplates Include="$(OutputPath)/*.tt" />
+    </ItemGroup>
     <Exec WorkingDirectory="$(ProjectDir)"
-          Condition="Exists($(DeviceMetadata)) And $([System.String]::new('%(Content.Link)').EndsWith('Device.tt'))"
-          Command="t4 %(Content.Identity) $(InterfaceFlags) -o=$(InterfacePath)\%(Content.Link)" />
+          ConsoleToMSBuild="true"
+          Condition="Exists($(DeviceMetadata)) And $([System.String]::new('%(TextTemplates.Identity)').EndsWith('Device.tt'))"
+          Command="t4 %(TextTemplates.Identity) $(InterfaceFlags) -o=$(InterfacePath)/%(TextTemplates.Filename).cs" />
+
     <Exec WorkingDirectory="$(ProjectDir)"
-          Condition="Exists($(IOMetadata)) And '%(Content.Link)' == 'Firmware.tt'"
-          Command="t4 %(Content.Identity) $(FirmwareFlags) -o=$(FirmwarePath)\app_ios_and_regs.h" />
+          ConsoleToMSBuild="true"
+          Condition="Exists($(DeviceMetadata)) And $([System.String]::new('%(TextTemplates.Identity)').EndsWith('harpdevice.tt'))"
+          Command="t4 %(TextTemplates.Identity) $(PythonInterfaceFlags) -o=$(PythonInterfacePath)/harp/devices/$pythonmodulenameshort$/%(TextTemplates.Filename) -v" />
+
+    <Exec WorkingDirectory="$(ProjectDir)"
+          ConsoleToMSBuild="true"
+          Condition="Exists($(IOMetadata)) And '%(TextTemplates.Identity)' == 'Firmware.tt'"
+          Command="t4 %(TextTemplates.Identity) $(FirmwareFlags) -o=$(FirmwarePath)\app_ios_and_regs.h" />
   </Target>
 </Project>

--- a/template/Bonsai.DeviceTemplate/PythonInterface/devicetemplate/.gitignore
+++ b/template/Bonsai.DeviceTemplate/PythonInterface/devicetemplate/.gitignore
@@ -1,0 +1,140 @@
+docs/source
+
+# From https://raw.githubusercontent.com/github/gitignore/main/Python.gitignore
+
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+cover/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+.pybuilder/
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow and github.com/pdm-project/pdm
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# pytype static type analyzer
+.pytype/
+
+# Cython debug symbols
+cython_debug/
+
+# Vscode config files
+.vscode/
+
+# PyCharm
+#  JetBrains specific template is maintained in a separate JetBrains.gitignore that can
+#  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
+#  and can be added to the global gitignore or merged into this file.  For a more nuclear
+#  option (not recommended) you can uncomment the following to ignore the entire idea folder.
+#.idea/

--- a/template/Bonsai.DeviceTemplate/PythonInterface/devicetemplate/.pre-commit-config.yaml
+++ b/template/Bonsai.DeviceTemplate/PythonInterface/devicetemplate/.pre-commit-config.yaml
@@ -1,0 +1,22 @@
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: "v5.0.0"
+    hooks:
+      - id: check-case-conflict
+      - id: check-merge-conflict
+      - id: check-toml
+      - id: check-yaml
+      - id: check-json
+        exclude: ^.devcontainer/devcontainer.json
+      - id: pretty-format-json
+        exclude: ^.devcontainer/devcontainer.json
+        args: [--autofix, --no-sort-keys]
+      - id: end-of-file-fixer
+      - id: trailing-whitespace
+
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: "v0.11.5"
+    hooks:
+      - id: ruff
+        args: [--exit-non-zero-on-fix]
+      - id: ruff-format

--- a/template/Bonsai.DeviceTemplate/PythonInterface/devicetemplate/CONTRIBUTING.md
+++ b/template/Bonsai.DeviceTemplate/PythonInterface/devicetemplate/CONTRIBUTING.md
@@ -1,0 +1,106 @@
+# Contributing to $projectnamelower$
+
+Contributions are welcome, and they are greatly appreciated!
+Every little bit helps, and credit will always be given.
+
+You can contribute in many ways:
+
+# Types of Contributions
+
+## Report Bugs
+
+Report bugs at https://github.com/fchampalimaud/harp.devices/issues
+
+If you are reporting a bug, please include:
+
+- Your operating system name and version.
+- Any details about your local setup that might be helpful in troubleshooting.
+- Detailed steps to reproduce the bug.
+
+## Write Documentation
+
+$projectnamelower$ could always use more documentation, whether as part of the official docs, in docstrings, or even on the web in blog posts, articles, and such.
+
+## Submit Feedback
+
+The best way to send feedback is to file an issue at https://github.com/fchampalimaud/harp.devices/issues.
+
+If you are proposing a new feature:
+
+- Explain in detail how it would work.
+- Keep the scope as narrow as possible, to make it easier to implement.
+- Remember that this is a volunteer-driven project, and that contributions
+  are welcome :)
+
+# Get Started!
+
+Ready to contribute? Here's how to set up `$projectnamelower$` for local development.
+Please note this documentation assumes you already have `uv` and `Git` installed and ready to go.
+
+1. Fork the `harp.devices` repo on GitHub.
+
+2. Clone your fork locally:
+
+```bash
+cd <directory_in_which_repo_should_be_created>
+git clone git@github.com:YOUR_NAME/harp.devices.git
+```
+
+3. Now we need to install the environment. Navigate into the directory of the device you want to work on. For example, if you are working on the `$projectnamelower$` device, run:
+
+```bash
+cd harp.devices/$projectnamelower$
+```
+
+Then, install and activate the environment with:
+
+```bash
+uv sync
+```
+
+4. Install pre-commit to run linters/formatters at commit time:
+
+```bash
+uv run pre-commit install
+```
+
+5. Create a branch for local development:
+
+```bash
+git checkout -b name-of-your-bugfix-or-feature
+```
+
+Now you can make your changes locally.
+
+6. Don't forget to add test cases for your added functionality to the `tests` directory.
+
+7. When you're done making changes, check that your changes pass the formatting tests.
+
+```bash
+make check
+```
+
+Now, validate that all unit tests are passing:
+
+```bash
+make test
+```
+
+10. Commit your changes and push your branch to GitHub:
+
+```bash
+git add .
+git commit -m "Your detailed description of your changes."
+git push origin name-of-your-bugfix-or-feature
+```
+
+11. Submit a pull request through the GitHub website.
+
+# Pull Request Guidelines
+
+Before you submit a pull request, check that it meets these guidelines:
+
+1. The pull request should include tests.
+
+2. If the pull request adds functionality, the docs should be updated.
+   Put your new functionality into a function with a docstring, and add the feature to the list in `README.md`.

--- a/template/Bonsai.DeviceTemplate/PythonInterface/devicetemplate/LICENSE
+++ b/template/Bonsai.DeviceTemplate/PythonInterface/devicetemplate/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Hardware and Software Platform, Champalimaud Foundation
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/template/Bonsai.DeviceTemplate/PythonInterface/devicetemplate/Makefile
+++ b/template/Bonsai.DeviceTemplate/PythonInterface/devicetemplate/Makefile
@@ -1,0 +1,54 @@
+.PHONY: install
+install: ## Install the virtual environment and install the pre-commit hooks
+	@echo "🚀 Creating virtual environment using uv"
+	@uv sync
+	@uv run pre-commit install
+
+.PHONY: check
+check: ## Run code quality tools.
+	@echo "🚀 Checking lock file consistency with 'pyproject.toml'"
+	@uv lock --locked
+	@echo "🚀 Linting code: Running pre-commit"
+	@uv run pre-commit run -a
+	@echo "🚀 Static type checking: Running mypy"
+	@uv run mypy
+	@echo "🚀 Checking for obsolete dependencies: Running deptry"
+	@uv run deptry .
+
+.PHONY: test
+test: ## Test the code with pytest
+	@echo "🚀 Testing code: Running pytest"
+	@uv run python -m pytest --doctest-modules
+
+.PHONY: build
+build: clean-build ## Build wheel file
+	@echo "🚀 Creating wheel file"
+	@uvx --from build pyproject-build --installer uv
+
+.PHONY: clean-build
+clean-build: ## Clean build artifacts
+	@echo "🚀 Removing build artifacts"
+	@uv run python -c "import shutil; import os; shutil.rmtree('dist') if os.path.exists('dist') else None"
+
+.PHONY: publish
+publish: ## Publish a release to PyPI.
+	@echo "🚀 Publishing."
+	@uvx twine upload --repository-url https://upload.pypi.org/legacy/ dist/*
+
+.PHONY: build-and-publish
+build-and-publish: build publish ## Build and publish.
+
+.PHONY: docs-test
+docs-test: ## Test if documentation can be built without warnings or errors
+	@uv run mkdocs build -s
+
+.PHONY: docs
+docs: ## Build and serve the documentation
+	@uv run mkdocs serve
+
+.PHONY: help
+help:
+	@uv run python -c "import re; \
+	[[print(f'\033[36m{m[0]:<20}\033[0m {m[1]}') for m in re.findall(r'^([a-zA-Z_-]+):.*?## (.*)$$', open(makefile).read(), re.M)] for makefile in ('$(MAKEFILE_LIST)').strip().split()]"
+
+.DEFAULT_GOAL := help

--- a/template/Bonsai.DeviceTemplate/PythonInterface/devicetemplate/README.md
+++ b/template/Bonsai.DeviceTemplate/PythonInterface/devicetemplate/README.md
@@ -1,0 +1,48 @@
+# $projectnamelower$
+
+[![PyPI](https://img.shields.io/pypi/v/$projectnamelower$)](https://pypi.org/project/$projectnamelower$/)
+
+This is a generated Harp device Python interface that interacts with the Harp protocol.
+
+- **Github repository**: <https://github.com/fchampalimaud/harp.devices/>
+- **Bug Tracker**: <https://github.com/fchampalimaud/harp.devices/issues>
+- **Documentation**: <https://fchampalimaud.github.io/pyharp/$projectnamelower$/>
+
+# Installation
+You can install the package using `uv` or `pip`:
+
+```bash
+uv add $projectnamelower$
+```
+or
+
+```bash
+pip install $projectnamelower$
+```
+
+# Usage example
+
+```python
+from harp.protocol import OperationMode
+from harp.devices.$pythonmodulenameshort$ import $projectnameshort$
+
+# Example usage of the $projectnameshort$ device
+with $projectnameshort$("/dev/ttyUSB0") as device: # For Windows, use "COM8" or similar
+    device.info()
+
+    # Set the device to active mode
+    device.set_mode(OperationMode.ACTIVE)
+
+    # Get the events
+    try:
+        while True:
+            for event in device.get_events():
+                # Do what you need with the event
+                print(event.payload)
+    except KeyboardInterrupt:
+        # Capture Ctrl+C to exit gracefully
+        print("Exiting...")
+    finally:
+        # Do what you need to do to clean up. Disconnect is automatically called with the "with" statement.
+        pass
+```

--- a/template/Bonsai.DeviceTemplate/PythonInterface/devicetemplate/docs/examples.mkdocs.yml
+++ b/template/Bonsai.DeviceTemplate/PythonInterface/devicetemplate/docs/examples.mkdocs.yml
@@ -1,0 +1,6 @@
+site_name: $projectnameshort$
+docs_dir: .
+
+nav:
+  - Index: examples/index.md
+  # _Add additional example markdown files here_

--- a/template/Bonsai.DeviceTemplate/PythonInterface/devicetemplate/docs/examples/index.md
+++ b/template/Bonsai.DeviceTemplate/PythonInterface/devicetemplate/docs/examples/index.md
@@ -1,0 +1,5 @@
+# $projectnameshort$ Examples
+
+<!-- Here you will find a collection of examples demonstrating how to use the `$projectnamelower$` Python package. Each example includes a brief description and the necessary code to get you started. -->
+
+_No examples are currently available. For suggestions, please open an issue on the GitHub repository._

--- a/template/Bonsai.DeviceTemplate/PythonInterface/devicetemplate/docs/index.md
+++ b/template/Bonsai.DeviceTemplate/PythonInterface/devicetemplate/docs/index.md
@@ -1,0 +1,1 @@
+{% include-markdown "../README.md" %}

--- a/template/Bonsai.DeviceTemplate/PythonInterface/devicetemplate/docs/modules.md
+++ b/template/Bonsai.DeviceTemplate/PythonInterface/devicetemplate/docs/modules.md
@@ -1,0 +1,1 @@
+::: harp.devices.$pythonmodulenameshort$.harpdevice

--- a/template/Bonsai.DeviceTemplate/PythonInterface/devicetemplate/docs/modules.md
+++ b/template/Bonsai.DeviceTemplate/PythonInterface/devicetemplate/docs/modules.md
@@ -1,1 +1,1 @@
-::: harp.devices.$pythonmodulenameshort$.harpdevice
+::: harp.devices.$pythonmodulenameshort$

--- a/template/Bonsai.DeviceTemplate/PythonInterface/devicetemplate/harp/devices/moduletemplate/__init__.py
+++ b/template/Bonsai.DeviceTemplate/PythonInterface/devicetemplate/harp/devices/moduletemplate/__init__.py
@@ -1,0 +1,1 @@
+from .harpdevice import *

--- a/template/Bonsai.DeviceTemplate/PythonInterface/devicetemplate/mkdocs.yml
+++ b/template/Bonsai.DeviceTemplate/PythonInterface/devicetemplate/mkdocs.yml
@@ -9,8 +9,6 @@ copyright: Maintained by the Hardware and Software Platform, Champalimaud Founda
 
 nav:
   - Home: index.md
-  # - Examples: 
-  #   - Example 1: examples/example01.md
   - Modules: modules.md
 plugins:
   - search

--- a/template/Bonsai.DeviceTemplate/PythonInterface/devicetemplate/mkdocs.yml
+++ b/template/Bonsai.DeviceTemplate/PythonInterface/devicetemplate/mkdocs.yml
@@ -1,0 +1,54 @@
+site_name: $pythonprojectname$
+repo_url: https://github.com/fchampalimaud/$pythonprojectname$
+site_url: https://fchampalimaud.github.io/$pythonprojectname$
+site_description: This is a generated Harp device Python interface that interacts with the Harp protocol.
+site_author: Hardware and Software Platform, Champalimaud Foundation
+edit_uri: edit/main/docs/
+repo_name: fchampalimaud/harp.devices
+copyright: Maintained by the Hardware and Software Platform, Champalimaud Foundation.
+
+nav:
+  - Home: index.md
+  # - Examples: 
+  #   - Example 1: examples/example01.md
+  - Modules: modules.md
+plugins:
+  - search
+  - mkdocstrings:
+      handlers:
+        python:
+          paths: ["$pythonmodulename$"]
+theme:
+  name: material
+  feature:
+    tabs: true
+  palette:
+    - media: "(prefers-color-scheme: light)"
+      scheme: default
+      primary: white
+      accent: deep orange
+      toggle:
+        icon: material/brightness-7
+        name: Switch to dark mode
+    - media: "(prefers-color-scheme: dark)"
+      scheme: slate
+      primary: black
+      accent: deep orange
+      toggle:
+        icon: material/brightness-4
+        name: Switch to light mode
+  icon:
+    repo: fontawesome/brands/github
+
+extra:
+  social:
+    - icon: fontawesome/brands/github
+      link: https://github.com/fchampalimaud/harp.devices
+    - icon: fontawesome/brands/python
+      link: https://pypi.org/project/$pythonprojectname$
+
+markdown_extensions:
+  - toc:
+      permalink: true
+  - pymdownx.arithmatex:
+      generic: true

--- a/template/Bonsai.DeviceTemplate/PythonInterface/devicetemplate/pyproject.toml
+++ b/template/Bonsai.DeviceTemplate/PythonInterface/devicetemplate/pyproject.toml
@@ -1,13 +1,13 @@
 [project]
 name = "$projectnamelower$"
-version = "0.1.0a1"
+version = "0.1.0a2"
 description = "This is a generated Harp device Python interface that interacts with the Harp protocol."
 authors = [{ name = "Hardware and Software Platform, Champalimaud Foundation", email = "software@research.fchampalimaud.org" }]
 readme = "README.md"
 keywords = ['python', 'harp']
 requires-python = ">=3.9,<4.0"
 dependencies = [
-    "harp-protocol==0.2.0",
+    "harp-serial==0.3.0",
 ]
 
 [project.urls]

--- a/template/Bonsai.DeviceTemplate/PythonInterface/devicetemplate/pyproject.toml
+++ b/template/Bonsai.DeviceTemplate/PythonInterface/devicetemplate/pyproject.toml
@@ -1,11 +1,11 @@
 [project]
 name = "$projectnamelower$"
-version = "0.1.0a3"
+version = "0.1.0a4"
 description = "This is a generated Harp device Python interface that interacts with the Harp protocol."
 authors = [{ name = "Hardware and Software Platform, Champalimaud Foundation", email = "software@research.fchampalimaud.org" }]
 readme = "README.md"
 keywords = ['python', 'harp']
-requires-python = ">=3.9,<4.0"
+requires-python = ">=3.10,<4.0"
 dependencies = [
     "harp-serial==0.4.0",
 ]

--- a/template/Bonsai.DeviceTemplate/PythonInterface/devicetemplate/pyproject.toml
+++ b/template/Bonsai.DeviceTemplate/PythonInterface/devicetemplate/pyproject.toml
@@ -1,0 +1,99 @@
+[project]
+name = "$projectnamelower$"
+version = "0.1.0a1"
+description = "This is a generated Harp device Python interface that interacts with the Harp protocol."
+authors = [{ name = "Hardware and Software Platform, Champalimaud Foundation", email = "software@research.fchampalimaud.org" }]
+readme = "README.md"
+keywords = ['python', 'harp']
+requires-python = ">=3.9,<4.0"
+dependencies = [
+    "harp-protocol==0.2.0",
+]
+
+[project.urls]
+Repository = "https://github.com/fchampalimaud/harp.devices/"
+"Bug Tracker" = "https://github.com/fchampalimaud/harp.devices/issues"
+Documentation = "https://fchampalimaud.github.io/pyharp/$projectnamelower$/"
+
+[dependency-groups]
+dev = [
+    "pytest>=7.2.0",
+    "pre-commit>=2.20.0",
+    "deptry>=0.23.0",
+    "mypy>=0.991",
+    "ruff>=0.11.5",
+    "mkdocs>=1.4.2",
+    "mkdocs-material>=8.5.10",
+    "mkdocstrings[python]>=0.26.1",
+]
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["harp"]
+
+[tool.setuptools]
+py-modules = ["harp"]
+
+[tool.mypy]
+files = ["harp/devices/$pythonmodulenameshort$"]
+disallow_untyped_defs = true
+disallow_any_unimported = true
+no_implicit_optional = true
+check_untyped_defs = true
+warn_return_any = true
+warn_unused_ignores = true
+show_error_codes = true
+
+[tool.ruff]
+target-version = "py39"
+line-length = 120
+fix = true
+
+[tool.ruff.lint]
+select = [
+    # flake8-2020
+    "YTT",
+    # flake8-bandit
+    "S",
+    # flake8-bugbear
+    "B",
+    # flake8-builtins
+    "A",
+    # flake8-comprehensions
+    "C4",
+    # flake8-debugger
+    "T10",
+    # flake8-simplify
+    "SIM",
+    # isort
+    "I",
+    # mccabe
+    "C90",
+    # pycodestyle
+    "E", "W",
+    # pyflakes
+    "F",
+    # pygrep-hooks
+    "PGH",
+    # pyupgrade
+    "UP",
+    # ruff
+    "RUF",
+    # tryceratops
+    "TRY",
+]
+ignore = [
+    # LineTooLong
+    "E501",
+    # DoNotAssignLambda
+    "E731",
+]
+
+[tool.ruff.lint.per-file-ignores]
+"tests/*" = ["S101"]
+
+[tool.ruff.format]
+preview = true

--- a/template/Bonsai.DeviceTemplate/PythonInterface/devicetemplate/pyproject.toml
+++ b/template/Bonsai.DeviceTemplate/PythonInterface/devicetemplate/pyproject.toml
@@ -28,14 +28,12 @@ dev = [
 ]
 
 [build-system]
-requires = ["hatchling"]
-build-backend = "hatchling.build"
+requires = ["uv_build>=0.9.5,<0.10.0"]
+build-backend = "uv_build"
 
-[tool.hatch.build.targets.wheel]
-packages = ["harp"]
-
-[tool.setuptools]
-py-modules = ["harp"]
+[tool.uv.build-backend]
+module-name = "harp.devices.$pythonmodulenameshort$"
+module-root = ""
 
 [tool.mypy]
 files = ["harp/devices/$pythonmodulenameshort$"]

--- a/template/Bonsai.DeviceTemplate/PythonInterface/devicetemplate/pyproject.toml
+++ b/template/Bonsai.DeviceTemplate/PythonInterface/devicetemplate/pyproject.toml
@@ -1,13 +1,13 @@
 [project]
 name = "$projectnamelower$"
-version = "0.1.0a2"
+version = "0.1.0a3"
 description = "This is a generated Harp device Python interface that interacts with the Harp protocol."
 authors = [{ name = "Hardware and Software Platform, Champalimaud Foundation", email = "software@research.fchampalimaud.org" }]
 readme = "README.md"
 keywords = ['python', 'harp']
 requires-python = ">=3.9,<4.0"
 dependencies = [
-    "harp-serial==0.3.0",
+    "harp-serial==0.4.0",
 ]
 
 [project.urls]


### PR DESCRIPTION
# PR changes

This PR introduces automatic generation of the Python interface for a device.

The base template used is a variation of <https://github.com/fpgmaas/cookiecutter-uv>.

The chosen python package structure is as follows:

```
harp/
    devices/
        <device_name>/
            __init__.py
            device.yml      # for reference of the device metadata used for the generation
            harpdevice.py
            
```

This PR is related to [PR#3](https://github.com/harp-tech/pyharp/pull/3) of the `pyharp` repository due to [PEP420](https://peps.python.org/pep-0420/) compliance for namespace packages, since we want to have a single namespace package for `harp` related packages.


The generated Python interface is a direct access type of interface, which means it provides a direct mapping to the device's functionality.

The package also includes a MKDocs configuration for documentation generation, focusing currently on the API documentation. The final documentation is available at <https://fchampalimaud.github.io/pyharp/>, which aggregates the documentation for the `pyharp` package and all devices under the `harp.devices` repository, currently available here: <https://github.com/fchampalimaud/harp.devices>.

