### PR TITLE
Inherit runtime templates from common base class

### DIFF
--- a/src/App.tt
+++ b/src/App.tt
@@ -1,4 +1,4 @@
-﻿<#@ template debug="true" hostspecific="false" visibility="internal" language="C#" #>
+﻿<#@ template debug="true" hostspecific="false" visibility="internal" language="C#" inherits="TemplateBase" #>
 <#@ parameter name="RegisterMetadataPath" type="string" #>
 <#@ import namespace="Harp.Generators" #>
 <#@ import namespace="System.IO" #>

--- a/src/AppFuncs.tt
+++ b/src/AppFuncs.tt
@@ -1,4 +1,4 @@
-﻿<#@ template debug="true" hostspecific="false" visibility="internal" language="C#" #>
+﻿<#@ template debug="true" hostspecific="false" visibility="internal" language="C#" inherits="TemplateBase" #>
 <#@ parameter name="RegisterMetadataPath" type="string" #>
 <#@ import namespace="Harp.Generators" #>
 <#@ import namespace="System.IO" #>

--- a/src/AppFuncsImpl.tt
+++ b/src/AppFuncsImpl.tt
@@ -1,4 +1,4 @@
-﻿<#@ template debug="true" hostspecific="false" visibility="internal" language="C#" #>
+﻿<#@ template debug="true" hostspecific="false" visibility="internal" language="C#" inherits="TemplateBase" #>
 <#@ parameter name="RegisterMetadataPath" type="string" #>
 <#@ import namespace="Harp.Generators" #>
 <#@ import namespace="System.IO" #>

--- a/src/AppImpl.tt
+++ b/src/AppImpl.tt
@@ -1,4 +1,4 @@
-﻿<#@ template debug="true" hostspecific="false" visibility="internal" language="C#" #>
+﻿<#@ template debug="true" hostspecific="false" visibility="internal" language="C#" inherits="TemplateBase" #>
 <#@ parameter name="RegisterMetadataPath" type="string" #>
 <#@ import namespace="Harp.Generators" #>
 <#@ import namespace="System.IO" #>

--- a/src/AppRegs.tt
+++ b/src/AppRegs.tt
@@ -1,4 +1,4 @@
-﻿<#@ template debug="true" hostspecific="false" visibility="internal" language="C#" #>
+﻿<#@ template debug="true" hostspecific="false" visibility="internal" language="C#" inherits="TemplateBase" #>
 <#@ parameter name="RegisterMetadataPath" type="string" #>
 <#@ parameter name="IOMetadataPath" type="string" #>
 <#@ import namespace="Harp.Generators" #>

--- a/src/AppRegsImpl.tt
+++ b/src/AppRegsImpl.tt
@@ -1,4 +1,4 @@
-﻿<#@ template debug="true" hostspecific="false" visibility="internal" language="C#" #>
+﻿<#@ template debug="true" hostspecific="false" visibility="internal" language="C#" inherits="TemplateBase" #>
 <#@ parameter name="RegisterMetadataPath" type="string" #>
 <#@ parameter name="IOMetadataPath" type="string" #>
 <#@ import namespace="Harp.Generators" #>

--- a/src/AsyncDevice.tt
+++ b/src/AsyncDevice.tt
@@ -1,4 +1,4 @@
-﻿<#@ template debug="true" hostspecific="false" visibility="internal" language="C#" #>
+﻿<#@ template debug="true" hostspecific="false" visibility="internal" language="C#" inherits="TemplateBase" #>
 <#@ parameter name="Namespace" type="string" #>
 <#@ parameter name="MetadataPath" type="string" #>
 <#@ import namespace="Harp.Generators" #>

--- a/src/Device.tt
+++ b/src/Device.tt
@@ -1,4 +1,4 @@
-﻿<#@ template debug="true" hostspecific="false" visibility="internal" language="C#" #>
+﻿<#@ template debug="true" hostspecific="false" visibility="internal" language="C#" inherits="TemplateBase" #>
 <#@ parameter name="Namespace" type="string" #>
 <#@ parameter name="MetadataPath" type="string" #>
 <#@ import namespace="YamlDotNet.Serialization.NamingConventions" #>

--- a/src/Interrupts.tt
+++ b/src/Interrupts.tt
@@ -1,4 +1,4 @@
-<#@ template debug="true" hostspecific="false" visibility="internal" language="C#" #>
+<#@ template debug="true" hostspecific="false" visibility="internal" language="C#" inherits="TemplateBase" #>
 <#@ parameter name="RegisterMetadataPath" type="string" #>
 <#@ parameter name="IOMetadataPath" type="string" #>
 <#@ import namespace="Harp.Generators" #>

--- a/src/TemplateBase.cs
+++ b/src/TemplateBase.cs
@@ -1,0 +1,119 @@
+﻿using System;
+using System.CodeDom.Compiler;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Harp.Generators;
+
+internal abstract class TemplateBase
+{
+    private StringBuilder builder;   
+    private CompilerErrorCollection errors;
+    private string currentIndent = string.Empty;
+    private Stack<int> indents;
+    
+    public virtual IDictionary<string, object> Session { get; set; }
+    
+    public StringBuilder GenerationEnvironment
+    {
+        get => builder ??= new StringBuilder();
+        set => builder = value;
+    }
+    
+    protected CompilerErrorCollection Errors => errors ??= [];
+    
+    public string CurrentIndent => currentIndent;
+    
+    private Stack<int> Indents => indents ??= [];
+    
+    public ToStringInstanceHelper ToStringHelper { get; } = new();
+
+    public abstract string TransformText();
+
+    public virtual void Initialize() { }
+    
+    public void Error(string message)
+    {
+        Errors.Add(new CompilerError(null, -1, -1, null, message));
+    }
+    
+    public void Warning(string message)
+    {
+        Errors.Add(new CompilerError(null, -1, -1, null, message)
+        {
+            IsWarning = true
+        });
+    }
+    
+    public string PopIndent()
+    {
+        if (Indents.Count == 0)
+            return string.Empty;
+        
+        int lastPos = currentIndent.Length - Indents.Pop();
+        string last = currentIndent.Substring(lastPos);
+        currentIndent = currentIndent.Substring(0, lastPos);
+        return last;
+    }
+    
+    public void PushIndent(string indent)
+    {
+        Indents.Push(indent.Length);
+        currentIndent += indent;
+    }
+    
+    public void ClearIndent()
+    {
+        currentIndent = string.Empty;
+        Indents.Clear();
+    }
+    
+    public void Write(string textToAppend)
+    {
+        GenerationEnvironment.Append(textToAppend);
+    }
+    
+    public void Write(string format, params object[] args)
+    {
+        GenerationEnvironment.AppendFormat(format, args);
+    }
+    
+    public void WriteLine(string textToAppend)
+    {
+        GenerationEnvironment.Append(currentIndent);
+        GenerationEnvironment.AppendLine(textToAppend);
+    }
+    
+    public void WriteLine(string format, params object[] args)
+    {
+        GenerationEnvironment.Append(currentIndent);
+        GenerationEnvironment.AppendFormat(format, args);
+        GenerationEnvironment.AppendLine();
+    }
+    
+    public class ToStringInstanceHelper
+    {    
+        private IFormatProvider formatProvider = System.Globalization.CultureInfo.InvariantCulture;
+        
+        public IFormatProvider FormatProvider
+        {
+            get => formatProvider;
+            set => formatProvider = value ?? formatProvider;
+        }
+        
+        public string ToStringWithCulture(object value)
+        {
+            if (value is null)
+                throw new ArgumentNullException(nameof(value));
+
+            if (value is IConvertible convertible)
+                return convertible.ToString(formatProvider);
+            
+            var method = value.GetType().GetMethod(nameof(ToString), [typeof(IFormatProvider)]);
+            if (method is not null)
+                return (string)method.Invoke(value, [formatProvider]);
+            
+            return value.ToString();
+        }
+    }
+}


### PR DESCRIPTION
This allows internalizing the entire runtime template inheritance tree, optimizing the base implementation, and avoiding code duplication.