### PR TITLE
Add docs to public API and avoid exposing helpers

### DIFF
--- a/src/Device.tt
+++ b/src/Device.tt
@@ -546,7 +546,6 @@ if (isPrivate)
                 member.Value,
                 "result",
                 register,
-                deviceMetadata,
                 assigned[payloadIndex]);
             assigned[payloadIndex] = true;
 #>

--- a/src/FirmwareGenerator.cs
+++ b/src/FirmwareGenerator.cs
@@ -1,8 +1,12 @@
-﻿using System.Collections.Generic;
+﻿using System.Collections;
+using System.Collections.Generic;
 using System.IO;
 
 namespace Harp.Generators;
 
+/// <summary>
+/// Provides automatic generation of device firmware implementations.
+/// </summary>
 public class FirmwareGenerator
 {
     readonly App _appTemplate = new();
@@ -13,6 +17,12 @@ public class FirmwareGenerator
     readonly AppRegsImpl _appRegsImplTemplate = new();
     readonly Interrupts _interruptsTemplate = new();
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="FirmwareGenerator"/> class with the
+    /// specified paths to device metadata and IO pin configuration files.
+    /// </summary>
+    /// <param name="registerMetadataFileName">The path to the file containing the device metadata.</param>
+    /// <param name="iosMetadataFileName">The path to the file containing the IO pin configuration.</param>
     public FirmwareGenerator(string registerMetadataFileName, string iosMetadataFileName)
     {
         var session = new Dictionary<string, object>
@@ -36,11 +46,19 @@ public class FirmwareGenerator
         _interruptsTemplate.Initialize();
     }
 
+    /// <summary>
+    /// Generates firmware header files complying with the specified metadata file.
+    /// </summary>
+    /// <returns>The generated device firmware headers.</returns>
     public FirmwareHeaders GenerateHeaders() =>
         new(App: _appTemplate.TransformText(),
             AppFuncs: _appFuncsTemplate.TransformText(),
             AppRegs: _appRegsTemplate.TransformText());
 
+    /// <summary>
+    /// Generates firmware implementation stubs complying with the specified metadata file.
+    /// </summary>
+    /// <returns>The generated device firmware implementation.</returns>
     public FirmwareImplementation GenerateImplementation() =>
         new(App: _appImplTemplate.TransformText(),
             AppFuncs: _appFuncsImplTemplate.TransformText(),
@@ -48,32 +66,97 @@ public class FirmwareGenerator
             Interrupts: _interruptsTemplate.TransformText());
 }
 
+/// <summary>
+/// Represents the generated device firmware header files.
+/// </summary>
+/// <param name="App">The contents of the header file declaring the app initialization function.</param>
+/// <param name="AppFuncs">The contents of the header file declaring app register functions.</param>
+/// <param name="AppRegs">The contents of the header file declaring app IO pins and register data.</param>
 public record struct FirmwareHeaders(string App, string AppFuncs, string AppRegs)
+    : IEnumerable<KeyValuePair<string, string>>
 {
+    /// <summary>
+    /// Represents the default name for the header file declaring the app initialization function.
+    /// </summary>
     public const string AppFileName = "app.h";
+
+    /// <summary>
+    /// Represents the default name for the header file declaring app register functions.
+    /// </summary>
     public const string AppFuncsFileName = "app_funcs.h";
+
+    /// <summary>
+    /// Represents the default name for the header file declaring app IO pins and register data.
+    /// </summary>
     public const string AppRegsFileName = "app_ios_and_regs.h";
 
-    public readonly IEnumerable<KeyValuePair<string, string>> GetGeneratedFileContents()
+    /// <summary>
+    /// Returns an enumerator that iterates through all the header files in the
+    /// generated implementation.
+    /// </summary>
+    /// <returns>
+    /// An enumerator that can be used to iterate through the generated header files.
+    /// </returns>
+    public readonly IEnumerator<KeyValuePair<string, string>> GetEnumerator()
     {
         yield return new(AppFileName, App);
         yield return new(AppFuncsFileName, AppFuncs);
         yield return new(AppRegsFileName, AppRegs);
     }
+
+    IEnumerator IEnumerable.GetEnumerator()
+    {
+        return GetEnumerator();
+    }
 }
 
+/// <summary>
+/// Represents the generated device firmware implementation.
+/// </summary>
+/// <param name="App">The generated source code implementing app initialization.</param>
+/// <param name="AppFuncs">The generated source code implementing app functions.</param>
+/// <param name="AppRegs">The generated source code implementing initialization of IO pins.</param>
+/// <param name="Interrupts">The generated source code implementing interrupt service routines.</param>
 public record struct FirmwareImplementation(string App, string AppFuncs, string AppRegs, string Interrupts)
+    : IEnumerable<KeyValuePair<string, string>>
 {
+    /// <summary>
+    /// Represents the default name for the file storing the app initialization source code.
+    /// </summary>
     public const string AppFileName = "app.c";
+
+    /// <summary>
+    /// Represents the default name for the file storing the source code for app functions.
+    /// </summary>
     public const string AppFuncsFileName = "app_funcs.c";
+
+    /// <summary>
+    /// Represents the default name for the file storing the initialization source code for IO pins.
+    /// </summary>
     public const string AppRegsFileName = "app_ios_and_regs.c";
+
+    /// <summary>
+    /// Represents the default name for the file storing the source code for interrupt service routines.
+    /// </summary>
     public const string InterruptsFileName = "interrupts.c";
 
-    public readonly IEnumerable<KeyValuePair<string, string>> GetGeneratedFileContents()
+    /// <summary>
+    /// Returns an enumerator that iterates through all the source code files in the
+    /// generated implementation.
+    /// </summary>
+    /// <returns>
+    /// An enumerator that can be used to iterate through the generated implementation files.
+    /// </returns>
+    public readonly IEnumerator<KeyValuePair<string, string>> GetEnumerator()
     {
         yield return new(AppFileName, App);
         yield return new(AppFuncsFileName, AppFuncs);
         yield return new(AppRegsFileName, AppRegs);
         yield return new(InterruptsFileName, Interrupts);
+    }
+
+    readonly IEnumerator IEnumerable.GetEnumerator()
+    {
+        return GetEnumerator();
     }
 }

--- a/src/Interface.cs
+++ b/src/Interface.cs
@@ -10,82 +10,273 @@ using YamlDotNet.Serialization.NamingConventions;
 
 namespace Harp.Generators;
 
+/// <summary>
+/// Represents information about Harp device functionality and operation registers.
+/// </summary>
 public class DeviceInfo
 {
+    /// <summary>
+    /// Specifies the name of the device.
+    /// </summary>
     public string Device;
+
+    /// <summary>
+    /// Specifies the unique identifier for this device type.
+    /// </summary>
     public int WhoAmI;
+
+    /// <summary>
+    /// Specifies the version of the device firmware.
+    /// </summary>
     public HarpVersion FirmwareVersion;
+
+    /// <summary>
+    /// Specifies the version of the device hardware.
+    /// </summary>
     public HarpVersion HardwareTargets;
+
+    /// <summary>
+    /// Specifies the collection of registers implementing the device function.
+    /// </summary>
     public Dictionary<string, RegisterInfo> Registers = [];
+
+    /// <summary>
+    /// Specifies the collection of masks available to be used with the different registers.
+    /// </summary>
     public Dictionary<string, BitMaskInfo> BitMasks = [];
+
+    /// <summary>
+    /// Specifies the collection of group masks available to be used with the different registers.
+    /// </summary>
     public Dictionary<string, GroupMaskInfo> GroupMasks = [];
 }
 
+/// <summary>
+/// Specifies the operations which can be used to access register data.
+/// </summary>
 [Flags]
 public enum RegisterAccess
 {
+    /// <summary>
+    /// Specifies that the register will accept a request to read the payload value. 
+    /// </summary>
     Read = 0x1,
+
+    /// <summary>
+    /// Specifies that the register will accept a request to write the payload value. 
+    /// </summary>
     Write = 0x2,
+
+    /// <summary>
+    /// Specifies that the device may send messages to the controller reporting the
+    /// contents of the register.
+    /// </summary>
     Event = 0x4
 }
 
+/// <summary>
+/// Specifies whether a register is exposed in the high-level interface.
+/// </summary>
 public enum RegisterVisibility
 {
+    /// <summary>
+    /// Specifies whether the register is exposed to the high-level interface.
+    /// </summary>
     Public,
+
+    /// <summary>
+    /// Specifies whether the register is hidden to the high-level interface.
+    /// </summary>
     Private
 }
 
+/// <summary>
+/// Specifies a custom converter which will be used to parse or format the payload or
+/// payload member value.
+/// </summary>
 public enum MemberConverter
 {
+    /// <summary>
+    /// Specifies that no custom conversion is required.
+    /// </summary>
     None,
+
+    /// <summary>
+    /// Specifies that the custom converter will operate on the specified payload type.
+    /// </summary>
     Payload,
+
+    /// <summary>
+    /// Specifies that the custom converter should operate directly in raw payload bytes.
+    /// </summary>
     RawPayload
 }
 
+/// <summary>
+/// Represents information about the functionality and operation of a specific register.
+/// </summary>
 public class RegisterInfo
 {
+    /// <summary>
+    /// Specifies the unique 8-bit address of the register.
+    /// </summary>
     [YamlMember(DefaultValuesHandling = DefaultValuesHandling.Preserve)]
     public int Address;
+
+    /// <summary>
+    /// Specifies the type of the register payload.
+    /// </summary>
     public PayloadType Type;
+
+    /// <summary>
+    /// Specifies the length of the register payload.
+    /// </summary>
     public int Length;
+
+    /// <summary>
+    /// Specifies the expected use of the register.
+    /// </summary>
     public RegisterAccess Access = RegisterAccess.Read;
+
+    /// <summary>
+    /// Specifies whether the register function is exposed in the high-level interface.
+    /// </summary>
     public RegisterVisibility Visibility;
+
+    /// <summary>
+    /// Specifies whether register values can be saved in non-volatile memory.
+    /// </summary>
     public bool Volatile;
+
+    /// <summary>
+    /// Specifies the name of the bit mask or group mask used to represent the payload value.
+    /// </summary>
     public string MaskType;
+
+    /// <summary>
+    /// Specifies the name of the type used to represent the payload value in the high-level interface.
+    /// </summary>
     public string InterfaceType;
+
+    /// <summary>
+    /// Specifies a custom converter which will be used to parse or format the payload value.
+    /// </summary>
     public MemberConverter Converter;
+
+    /// <summary>
+    /// Specifies the minimum allowable value for the payload.
+    /// </summary>
     public float? MinValue;
+
+    /// <summary>
+    /// Specifies the maximum allowable value for the payload.
+    /// </summary>
     public float? MaxValue;
+
+    /// <summary>
+    /// Specifies the default value for the payload.
+    /// </summary>
     public float? DefaultValue;
+
+    /// <summary>
+    /// Specifies a summary description of the register function.
+    /// </summary>
     public string Description = "";
+
+    /// <summary>
+    /// Specifies a collection of payload members describing the contents
+    /// of the raw payload value.
+    /// </summary>
     public Dictionary<string, PayloadMemberInfo> PayloadSpec;
 
+    /// <summary>
+    /// Gets a value indicating whether a custom converter will be used to parse or
+    /// format the payload.
+    /// </summary>
     [YamlIgnore]
     public bool HasConverter => Converter > MemberConverter.None;
 
+    /// <summary>
+    /// Gets the name of the type used to represent the payload for interface conversions.
+    /// </summary>
     [YamlIgnore]
     public string PayloadInterfaceType => Converter == MemberConverter.RawPayload
         ? "ArraySegment<byte>"
         : TemplateHelper.GetInterfaceType(Type, Length);
 }
 
+/// <summary>
+/// Represents information about a specific payload member.
+/// </summary>
 public class PayloadMemberInfo
 {
+    /// <summary>
+    /// Specifies the mask used to read and write this payload member.
+    /// </summary>
     [YamlConverter(typeof(HexValueTypeConverter))]
     public int? Mask;
+
+    /// <summary>
+    /// Specifies the zero-based index at which encoding of this payload member starts.
+    /// </summary>
     public int? Offset;
+
+    /// <summary>
+    /// Specifies the number of elements used to encode this payload member.
+    /// </summary>
     public int? Length;
+
+    /// <summary>
+    /// Specifies the name of the bit mask or group mask used to represent this payload member.
+    /// </summary>
     public string MaskType;
+
+    /// <summary>
+    /// Specifies the name of the type used to represent this payload member in the high-level interface.
+    /// </summary>
     public string InterfaceType;
+
+    /// <summary>
+    /// Specifies a custom converter which will be used to parse or format this payload member.
+    /// </summary>
     public MemberConverter Converter;
+
+    /// <summary>
+    /// Specifies the minimum allowable value for this payload member.
+    /// </summary>
     public float? MinValue;
+
+    /// <summary>
+    /// Specifies the maximum allowable value for this payload member.
+    /// </summary>
     public float? MaxValue;
+
+    /// <summary>
+    /// Specifies the default value for this payload member.
+    /// </summary>
     public float? DefaultValue;
+
+    /// <summary>
+    /// Specifies a summary description of this payload member.
+    /// </summary>
     public string Description = "";
 
+    /// <summary>
+    /// Gets a value indicating whether a custom converter will be used to parse or
+    /// format this payload member.
+    /// </summary>
     [YamlIgnore]
     public bool HasConverter => Converter > MemberConverter.None;
 
+    /// <summary>
+    /// Gets the name of the type used to represent this payload member in the high-level interface.
+    /// </summary>
+    /// <param name="payloadType">
+    /// The raw payload type of the register where this payload member is located.
+    /// </param>
+    /// <returns>
+    /// The high-level interface type.
+    /// </returns>
     public string GetConverterInterfaceType(PayloadType payloadType)
     {
         return Converter switch
@@ -99,58 +290,76 @@ public class PayloadMemberInfo
     }
 }
 
+/// <summary>
+/// Represents a bit mask used for reading or writing specific registers.
+/// </summary>
 public class BitMaskInfo
 {
+    /// <summary>
+    /// Specifies a summary description of the bit mask function.
+    /// </summary>
     public string Description = "";
+
+    /// <summary>
+    /// Specifies the collection of bit mask values.
+    /// </summary>
     public Dictionary<string, MaskValue> Bits = [];
 
+    /// <summary>
+    /// Gets the name of the underlying primitive type used to represent a bit mask value
+    /// in the high-level interface.
+    /// </summary>
     [YamlIgnore]
     public string InterfaceType => TemplateHelper.GetInterfaceType(Bits);
 }
 
+/// <summary>
+/// Represents a group mask used for reading or writing specific registers.
+/// </summary>
 public class GroupMaskInfo
 {
+    /// <summary>
+    /// Specifies a summary description of the group mask function.
+    /// </summary>
     public string Description = "";
+
+    /// <summary>
+    /// Specifies the collection of group mask values.
+    /// </summary>
     public Dictionary<string, MaskValue> Values = [];
 
+    /// <summary>
+    /// Gets the name of the underlying primitive type used to represent a group mask value
+    /// in the high-level interface.
+    /// </summary>
     [YamlIgnore]
     public string InterfaceType => TemplateHelper.GetInterfaceType(Values);
 }
 
+/// <summary>
+/// Represents a bit mask or group mask value.
+/// </summary>
 public class MaskValue
 {
+    /// <summary>
+    /// Specifies the numerical mask value.
+    /// </summary>
     [YamlConverter(typeof(HexValueTypeConverter))]
     public int Value;
+
+    /// <summary>
+    /// Specifies a summary description of the mask value function.
+    /// </summary>
     public string Description;
 }
 
-public static partial class TemplateHelper
+internal static partial class TemplateHelper
 {
-    public static readonly IDeserializer Deserializer = new DeserializerBuilder()
-        .WithNamingConvention(CamelCaseNamingConvention.Instance)
-        .WithTypeConverter(RegisterAccessTypeConverter.Instance)
-        .WithTypeConverter(MaskValueTypeConverter.Instance)
-        .WithTypeConverter(HarpVersionTypeConverter.Instance)
-        .WithTypeConverter(HexValueTypeConverter.Instance)
-        .Build();
-
-    public static readonly ISerializer Serializer = new SerializerBuilder()
-        .WithNamingConvention(CamelCaseNamingConvention.Instance)
-        .WithTypeConverter(RegisterAccessTypeConverter.Instance)
-        .WithTypeConverter(MaskValueTypeConverter.Instance)
-        .WithTypeConverter(HarpVersionTypeConverter.Instance)
-        .WithTypeConverter(HexValueTypeConverter.Instance)
-        .ConfigureDefaultValuesHandling(
-            DefaultValuesHandling.OmitNull |
-            DefaultValuesHandling.OmitDefaults |
-            DefaultValuesHandling.OmitEmptyCollections)
-        .Build();
-
     public static DeviceInfo ReadDeviceMetadata(string path)
     {
         using var reader = new StreamReader(path);
         var parser = new MergingParser(new Parser(reader));
-        return Deserializer.Deserialize<DeviceInfo>(parser);
+        return MetadataDeserializer.Instance.Deserialize<DeviceInfo>(parser);
     }
 
     public static string GetInterfaceType(string name, RegisterInfo register)
@@ -407,7 +616,6 @@ public static partial class TemplateHelper
         PayloadMemberInfo member,
         string expression,
         RegisterInfo register,
-        DeviceInfo deviceMetadata,
         bool assigned)
     {
         var payloadType = register.Type;
@@ -438,7 +646,6 @@ public static partial class TemplateHelper
             return $"{expression}{memberIndexer}{memberConversion}";
         }
     }
-
 
     public static string GetPayloadMemberValueFormatter(
         string name,

--- a/src/InterfaceGenerator.cs
+++ b/src/InterfaceGenerator.cs
@@ -1,13 +1,23 @@
-﻿using System.Collections.Generic;
+﻿using System.Collections;
+using System.Collections.Generic;
 using System.IO;
 
 namespace Harp.Generators;
 
+/// <summary>
+/// Provides automatic generation of reactive device interface implementations.
+/// </summary>
 public sealed class InterfaceGenerator
 {
     readonly Device _deviceTemplate = new();
     readonly AsyncDevice _asyncDeviceTemplate = new();
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="InterfaceGenerator"/> class with the
+    /// specified path to the device metadata file and target namespace for generated code.
+    /// </summary>
+    /// <param name="metadataFileName">The path to the file containing the device metadata.</param>
+    /// <param name="ns">The target namespace to use for all generated code.</param>
     public InterfaceGenerator(string metadataFileName, string ns)
     {
         var session = new Dictionary<string, object>
@@ -21,19 +31,48 @@ public sealed class InterfaceGenerator
         _asyncDeviceTemplate.Initialize();
     }
 
+    /// <summary>
+    /// Generates a device interface implementation complying with the specified metadata file.
+    /// </summary>
+    /// <returns>The generated device interface implementation.</returns>
     public InterfaceImplementation GenerateImplementation() =>
         new(Device: _deviceTemplate.TransformText(),
             AsyncDevice: _asyncDeviceTemplate.TransformText());
 }
 
+/// <summary>
+/// Represents the generated device interface implementation.
+/// </summary>
+/// <param name="Device">The generated source code implementing the device reactive interface.</param>
+/// <param name="AsyncDevice">The generated source code for the device async interface implementation.</param>
 public record struct InterfaceImplementation(string Device, string AsyncDevice)
+    : IEnumerable<KeyValuePair<string, string>>
 {
+    /// <summary>
+    /// Represents the default name for the file storing the device implementation source code.
+    /// </summary>
     public const string DeviceFileName = "Device.Generated.cs";
+
+    /// <summary>
+    /// Represents the default name for the file storing the async device implementation source code.
+    /// </summary>
     public const string AsyncDeviceFileName = "AsyncDevice.Generated.cs";
 
-    public readonly IEnumerable<KeyValuePair<string, string>> GetGeneratedFileContents()
+    /// <summary>
+    /// Returns an enumerator that iterates through all the source code files in the
+    /// generated implementation.
+    /// </summary>
+    /// <returns>
+    /// An enumerator that can be used to iterate through the generated implementation files.
+    /// </returns>
+    public readonly IEnumerator<KeyValuePair<string, string>> GetEnumerator()
     {
         yield return new(DeviceFileName, Device);
         yield return new(AsyncDeviceFileName, AsyncDevice);
+    }
+
+    readonly IEnumerator IEnumerable.GetEnumerator()
+    {
+        return GetEnumerator();
     }
 }

--- a/src/MetadataDeserializer.cs
+++ b/src/MetadataDeserializer.cs
@@ -1,0 +1,29 @@
+﻿using YamlDotNet.Serialization;
+using YamlDotNet.Serialization.NamingConventions;
+
+namespace Harp.Generators;
+
+/// <summary>
+/// Provides methods and objects used to deserialize device metadata objects.
+/// </summary>
+public static class MetadataDeserializer
+{
+    /// <summary>
+    /// Gets an <see cref="IDeserializer"/> instance that can be used to deserialize
+    /// device metadata objects.
+    /// </summary>
+    public static readonly IDeserializer Instance = new DeserializerBuilder()
+        .WithNamingConvention(CamelCaseNamingConvention.Instance)
+        .WithTypeConverter(RegisterAccessTypeConverter.Instance)
+        .WithTypeConverter(MaskValueTypeConverter.Instance)
+        .WithTypeConverter(HarpVersionTypeConverter.Instance)
+        .WithTypeConverter(HexValueTypeConverter.Instance)
+        .WithPortPinInfoTypeConverter()
+        .Build();
+
+    static DeserializerBuilder WithPortPinInfoTypeConverter(this DeserializerBuilder deserializerBuilder)
+    {
+        var portPinConverter = new PortPinInfoTypeConverter(deserializerBuilder.Build());
+        return deserializerBuilder.WithTypeConverter(portPinConverter);
+    }
+}

--- a/src/MetadataSerializer.cs
+++ b/src/MetadataSerializer.cs
@@ -1,0 +1,26 @@
+﻿using YamlDotNet.Serialization;
+using YamlDotNet.Serialization.NamingConventions;
+
+namespace Harp.Generators;
+
+/// <summary>
+/// Provides methods and objects used to serialize device metadata objects.
+/// </summary>
+public static class MetadataSerializer
+{
+    /// <summary>
+    /// Gets an <see cref="ISerializer"/> instance that can be used to serialize
+    /// device metadata objects.
+    /// </summary>
+    public static readonly ISerializer Instance = new SerializerBuilder()
+        .WithNamingConvention(CamelCaseNamingConvention.Instance)
+        .WithTypeConverter(RegisterAccessTypeConverter.Instance)
+        .WithTypeConverter(MaskValueTypeConverter.Instance)
+        .WithTypeConverter(HarpVersionTypeConverter.Instance)
+        .WithTypeConverter(HexValueTypeConverter.Instance)
+        .ConfigureDefaultValuesHandling(
+            DefaultValuesHandling.OmitNull |
+            DefaultValuesHandling.OmitDefaults |
+            DefaultValuesHandling.OmitEmptyCollections)
+        .Build();
+}

--- a/tests/MetadataSerializerTests.cs
+++ b/tests/MetadataSerializerTests.cs
@@ -42,8 +42,8 @@ public sealed class MetadataSerializerTests
         var metadataContents = File.ReadAllText(metadataFileName);
         metadataContents = NormalizeYaml(metadataContents);
 
-        var deviceMetadata = TemplateHelper.Deserializer.Deserialize<DeviceInfo>(metadataContents);
-        var roundTripContents = TemplateHelper.Serializer.Serialize(deviceMetadata);
+        var deviceMetadata = MetadataDeserializer.Instance.Deserialize<DeviceInfo>(metadataContents);
+        var roundTripContents = MetadataSerializer.Instance.Serialize(deviceMetadata);
         try
         {
             Assert.AreEqual(metadataContents, roundTripContents);


### PR DESCRIPTION
XML documentation comments are added to all generator model objects.

Serializer and deserializer classes are refactored into separate helpers providing unified objects which can be used to work with all generator models.