### PR TITLE
Refactor templates to work on metadata objects

### DIFF
--- a/src/App.tt
+++ b/src/App.tt
@@ -1,5 +1,5 @@
 ﻿<#@ template debug="true" hostspecific="false" visibility="internal" language="C#" inherits="TemplateBase" #>
-<#@ parameter name="RegisterMetadataPath" type="string" #>
+<#@ parameter name="DeviceMetadata" type="DeviceInfo" #>
 <#@ import namespace="Harp.Generators" #>
 <#@ import namespace="System.IO" #>
 <#@ output extension=".h" #>
@@ -11,20 +11,17 @@
 /************************************************************************/
 /* Define versions                                                      */
 /************************************************************************/
-<#
-var deviceMetadata = TemplateHelper.ReadDeviceMetadata(RegisterMetadataPath);
-#>
 #ifndef MAJOR_HW_VERSION
-#define MAJOR_HW_VERSION <#= deviceMetadata.HardwareTargets.Major #>
+#define MAJOR_HW_VERSION <#= DeviceMetadata.HardwareTargets.Major #>
 #endif
 #ifndef MINOR_HW_VERSION
-#define MINOR_HW_VERSION <#= deviceMetadata.HardwareTargets.Minor #>
+#define MINOR_HW_VERSION <#= DeviceMetadata.HardwareTargets.Minor #>
 #endif
 #ifndef MAJOR_FW_VERSION
-#define MAJOR_FW_VERSION <#= deviceMetadata.FirmwareVersion.Major #>
+#define MAJOR_FW_VERSION <#= DeviceMetadata.FirmwareVersion.Major #>
 #endif
 #ifndef MINOR_FW_VERSION
-#define MINOR_FW_VERSION <#= deviceMetadata.FirmwareVersion.Minor #>
+#define MINOR_FW_VERSION <#= DeviceMetadata.FirmwareVersion.Minor #>
 #endif
 #ifndef ASSEMBLY_VERSION
 #define ASSEMBLY_VERSION 0

--- a/src/AppFuncs.tt
+++ b/src/AppFuncs.tt
@@ -1,5 +1,5 @@
 ﻿<#@ template debug="true" hostspecific="false" visibility="internal" language="C#" inherits="TemplateBase" #>
-<#@ parameter name="RegisterMetadataPath" type="string" #>
+<#@ parameter name="DeviceMetadata" type="DeviceInfo" #>
 <#@ import namespace="Harp.Generators" #>
 <#@ import namespace="System.IO" #>
 <#@ import namespace="System.Linq" #>
@@ -24,15 +24,12 @@
 	#define false 0
 #endif
 
-<#
-var deviceMetadata = TemplateHelper.ReadDeviceMetadata(RegisterMetadataPath);
-#>
 
 /************************************************************************/
 /* Prototypes                                                           */
 /************************************************************************/
 <#
-foreach (var registerMetadata in deviceMetadata.Registers)
+foreach (var registerMetadata in DeviceMetadata.Registers)
 {
     var registerName = FirmwareNamingConvention.Instance.Apply(registerMetadata.Key);
 #>
@@ -42,7 +39,7 @@ void app_read_REG_<#= registerName #>(void);
 #>
 
 <#
-foreach (var registerMetadata in deviceMetadata.Registers)
+foreach (var registerMetadata in DeviceMetadata.Registers)
 {
     var registerName = FirmwareNamingConvention.Instance.Apply(registerMetadata.Key);
 #>

--- a/src/AppFuncsImpl.tt
+++ b/src/AppFuncsImpl.tt
@@ -1,5 +1,5 @@
 ﻿<#@ template debug="true" hostspecific="false" visibility="internal" language="C#" inherits="TemplateBase" #>
-<#@ parameter name="RegisterMetadataPath" type="string" #>
+<#@ parameter name="DeviceMetadata" type="DeviceInfo" #>
 <#@ import namespace="Harp.Generators" #>
 <#@ import namespace="System.IO" #>
 <#@ import namespace="System.Linq" #>
@@ -10,8 +10,7 @@
 #include "app_ios_and_regs.h"
 #include "hwbp_core.h"
 <#
-var deviceMetadata = TemplateHelper.ReadDeviceMetadata(RegisterMetadataPath);
-var deviceRegisters = deviceMetadata.Registers;
+var deviceRegisters = DeviceMetadata.Registers;
 int registerIndex;
 #>
 

--- a/src/AppImpl.tt
+++ b/src/AppImpl.tt
@@ -1,5 +1,5 @@
 ﻿<#@ template debug="true" hostspecific="false" visibility="internal" language="C#" inherits="TemplateBase" #>
-<#@ parameter name="RegisterMetadataPath" type="string" #>
+<#@ parameter name="DeviceMetadata" type="DeviceInfo" #>
 <#@ import namespace="Harp.Generators" #>
 <#@ import namespace="System.IO" #>
 <#@ output extension=".c" #>
@@ -24,10 +24,7 @@ extern bool (*app_func_wr_pointer[])(void*);
 /************************************************************************/
 /* Initialize app                                                       */
 /************************************************************************/
-<#
-var deviceMetadata = TemplateHelper.ReadDeviceMetadata(RegisterMetadataPath);
-#>
-static const uint8_t default_device_name[] = "<#= deviceMetadata.Device #>";
+static const uint8_t default_device_name[] = "<#= DeviceMetadata.Device #>";
 
 void hwbp_app_initialize(void)
 {
@@ -40,7 +37,7 @@ void hwbp_app_initialize(void)
     
    	/* Start core */
     core_func_start_core(
-        <#= deviceMetadata.WhoAmI #>,
+        <#= DeviceMetadata.WhoAmI #>,
         hwH, hwL,
         fwH, fwL,
         ass,

--- a/src/AppRegs.tt
+++ b/src/AppRegs.tt
@@ -1,6 +1,6 @@
 ﻿<#@ template debug="true" hostspecific="false" visibility="internal" language="C#" inherits="TemplateBase" #>
-<#@ parameter name="RegisterMetadataPath" type="string" #>
-<#@ parameter name="IOMetadataPath" type="string" #>
+<#@ parameter name="DeviceMetadata" type="DeviceInfo" #>
+<#@ parameter name="PortPinMetadata" type="Dictionary<string, PortPinInfo>" #>
 <#@ import namespace="Harp.Generators" #>
 <#@ import namespace="System.IO" #>
 <#@ import namespace="System.Linq" #>
@@ -11,17 +11,15 @@
 #define _APP_IOS_AND_REGS_H_
 #include "cpu.h"
 <#
-var deviceMetadata = TemplateHelper.ReadDeviceMetadata(RegisterMetadataPath);
-var portPinMetadata = TemplateHelper.ReadPortPinMetadata(IOMetadataPath);
-var inputPins = TemplateHelper.GetPortPinsOfType<InputPinInfo>(portPinMetadata).ToList();
-var outputPins = TemplateHelper.GetPortPinsOfType<OutputPinInfo>(portPinMetadata).ToList();
-var deviceName = deviceMetadata.Device;
+var inputPins = TemplateHelper.GetPortPinsOfType<InputPinInfo>(PortPinMetadata).ToList();
+var outputPins = TemplateHelper.GetPortPinsOfType<OutputPinInfo>(PortPinMetadata).ToList();
+var deviceName = DeviceMetadata.Device;
 
 int maxRegisterNameLength = 0;
 int minRegisterAddress = byte.MaxValue;
 int maxRegisterAddress = 32;
 int totalRegisterSize = 0;
-foreach (var registerMetadata in deviceMetadata.Registers)
+foreach (var registerMetadata in DeviceMetadata.Registers)
 {
     var register = registerMetadata.Value;
     var registerName = FirmwareNamingConvention.Instance.Apply(registerMetadata.Key);
@@ -113,7 +111,7 @@ if (outputPins.Count > 0)
 typedef struct
 {
 <#
-foreach (var registerMetadata in deviceMetadata.Registers)
+foreach (var registerMetadata in DeviceMetadata.Registers)
 {
     var register = registerMetadata.Value;
     var registerName = FirmwareNamingConvention.Instance.Apply(registerMetadata.Key);
@@ -131,7 +129,7 @@ foreach (var registerMetadata in deviceMetadata.Registers)
 /************************************************************************/
 /* Registers */
 <#
-foreach (var registerMetadata in deviceMetadata.Registers)
+foreach (var registerMetadata in DeviceMetadata.Registers)
 {
     var register = registerMetadata.Value;
     var registerName = FirmwareNamingConvention.Instance.Apply(registerMetadata.Key);
@@ -159,18 +157,18 @@ foreach (var registerMetadata in deviceMetadata.Registers)
 /* Registers' bits                                                      */
 /************************************************************************/
 <#
-var maxBitNameLength = deviceMetadata.BitMasks.Values
+var maxBitNameLength = DeviceMetadata.BitMasks.Values
     .SelectMany(mask => mask.Bits)
     .Select(bitField => FirmwareNamingConvention.Instance.Apply(bitField.Key).Length)
     .Prepend(0).Max();
-var maxMemberNameLength = (from groupMask in deviceMetadata.GroupMasks
+var maxMemberNameLength = (from groupMask in DeviceMetadata.GroupMasks
                            let maskName = FirmwareGroupMaskNamingConvention.Instance.Apply(groupMask.Key)
                            from member in groupMask.Value.Values
                            let memberName = FirmwareNamingConvention.Instance.Apply(member.Key)
                            select maskName.Length + memberName.Length)
                            .Prepend(0).Max();
 var maxBitMemberNameLength = Math.Max(maxBitNameLength, maxMemberNameLength);
-foreach (var bitMask in deviceMetadata.BitMasks)
+foreach (var bitMask in DeviceMetadata.BitMasks)
 {
     var mask = bitMask.Value;
     foreach (var bitField in mask.Bits)
@@ -187,7 +185,7 @@ foreach (var bitMask in deviceMetadata.BitMasks)
 }
 #>
 <#
-foreach (var groupMask in deviceMetadata.GroupMasks)
+foreach (var groupMask in DeviceMetadata.GroupMasks)
 {
     var mask = groupMask.Value;
     var maskSelect = TemplateHelper.GetMaskSelect(mask).ToString("X2");

--- a/src/AppRegsImpl.tt
+++ b/src/AppRegsImpl.tt
@@ -1,6 +1,6 @@
 ﻿<#@ template debug="true" hostspecific="false" visibility="internal" language="C#" inherits="TemplateBase" #>
-<#@ parameter name="RegisterMetadataPath" type="string" #>
-<#@ parameter name="IOMetadataPath" type="string" #>
+<#@ parameter name="DeviceMetadata" type="DeviceInfo" #>
+<#@ parameter name="PortPinMetadata" type="Dictionary<string, PortPinInfo>" #>
 <#@ import namespace="Harp.Generators" #>
 <#@ import namespace="System.IO" #>
 <#@ import namespace="System.Linq" #>
@@ -13,12 +13,10 @@
 
 extern AppRegs app_regs;
 <#
-var deviceMetadata = TemplateHelper.ReadDeviceMetadata(RegisterMetadataPath);
-var portPinMetadata = TemplateHelper.ReadPortPinMetadata(IOMetadataPath);
-var inputPins = TemplateHelper.GetPortPinsOfType<InputPinInfo>(portPinMetadata).ToList();
-var outputPins = TemplateHelper.GetPortPinsOfType<OutputPinInfo>(portPinMetadata).ToList();
-var deviceRegisters = deviceMetadata.Registers;
-var deviceName = deviceMetadata.Device;
+var inputPins = TemplateHelper.GetPortPinsOfType<InputPinInfo>(PortPinMetadata).ToList();
+var outputPins = TemplateHelper.GetPortPinsOfType<OutputPinInfo>(PortPinMetadata).ToList();
+var deviceRegisters = DeviceMetadata.Registers;
+var deviceName = DeviceMetadata.Device;
 int registerIndex;
 
 int maxRegisterNameLength = 0;

--- a/src/AsyncDevice.tt
+++ b/src/AsyncDevice.tt
@@ -1,6 +1,6 @@
 ﻿<#@ template debug="true" hostspecific="false" visibility="internal" language="C#" inherits="TemplateBase" #>
 <#@ parameter name="Namespace" type="string" #>
-<#@ parameter name="MetadataPath" type="string" #>
+<#@ parameter name="DeviceMetadata" type="DeviceInfo" #>
 <#@ import namespace="Harp.Generators" #>
 <#@ import namespace="System.IO" #>
 <#@ import namespace="System.Linq" #>
@@ -8,9 +8,8 @@
 <#@ import namespace="System.Collections.Generic" #>
 <#@ output extension=".Generated.cs" #>
 <#
-var deviceMetadata = TemplateHelper.ReadDeviceMetadata(MetadataPath);
-var publicRegisters = deviceMetadata.Registers.Where(register => register.Value.Visibility == RegisterVisibility.Public).ToList();
-var deviceName = deviceMetadata.Device;
+var publicRegisters = DeviceMetadata.Registers.Where(register => register.Value.Visibility == RegisterVisibility.Public).ToList();
+var deviceName = DeviceMetadata.Device;
 #>
 using Bonsai.Harp;
 using System.Threading;

--- a/src/Device.tt
+++ b/src/Device.tt
@@ -1,6 +1,6 @@
 ﻿<#@ template debug="true" hostspecific="false" visibility="internal" language="C#" inherits="TemplateBase" #>
 <#@ parameter name="Namespace" type="string" #>
-<#@ parameter name="MetadataPath" type="string" #>
+<#@ parameter name="DeviceMetadata" type="DeviceInfo" #>
 <#@ import namespace="YamlDotNet.Serialization.NamingConventions" #>
 <#@ import namespace="Harp.Generators" #>
 <#@ import namespace="System.IO" #>
@@ -9,10 +9,9 @@
 <#@ import namespace="System.Collections.Generic" #>
 <#@ output extension=".Generated.cs" #>
 <#
-var deviceMetadata = TemplateHelper.ReadDeviceMetadata(MetadataPath);
-var publicRegisters = deviceMetadata.Registers.Where(register => register.Value.Visibility == RegisterVisibility.Public).ToList();
-var deviceRegisters = deviceMetadata.Registers;
-var deviceName = deviceMetadata.Device;
+var publicRegisters = DeviceMetadata.Registers.Where(register => register.Value.Visibility == RegisterVisibility.Public).ToList();
+var deviceRegisters = DeviceMetadata.Registers;
+var deviceName = DeviceMetadata.Device;
 #>
 using Bonsai;
 using Bonsai.Harp;
@@ -38,7 +37,7 @@ namespace <#= Namespace #>
         /// Represents the unique identity class of the <see cref="<#= deviceName #>"/> device.
         /// This field is constant.
         /// </summary>
-        public const int WhoAmI = <#= deviceMetadata.WhoAmI #>;
+        public const int WhoAmI = <#= DeviceMetadata.WhoAmI #>;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="Device"/> class.
@@ -479,7 +478,7 @@ if (isPrivate)
                 member.Value,
                 "payload",
                 register,
-                deviceMetadata);
+                DeviceMetadata);
 #>
             result.<#= member.Key #> = <#= memberConversion #>;
 <#
@@ -919,7 +918,7 @@ foreach (var registerMetadata in deviceRegisters)
 }
 #>
 <#
-foreach (var bitMask in deviceMetadata.BitMasks)
+foreach (var bitMask in DeviceMetadata.BitMasks)
 {
     var mask = bitMask.Value;
 #>
@@ -974,7 +973,7 @@ foreach (var bitMask in deviceMetadata.BitMasks)
 }
 #>
 <#
-foreach (var groupMask in deviceMetadata.GroupMasks)
+foreach (var groupMask in DeviceMetadata.GroupMasks)
 {
     var mask = groupMask.Value;
 #>

--- a/src/FirmwareGenerator.cs
+++ b/src/FirmwareGenerator.cs
@@ -19,16 +19,16 @@ public class FirmwareGenerator
 
     /// <summary>
     /// Initializes a new instance of the <see cref="FirmwareGenerator"/> class with the
-    /// specified paths to device metadata and IO pin configuration files.
+    /// specified device metadata and IO pin configuration.
     /// </summary>
-    /// <param name="registerMetadataFileName">The path to the file containing the device metadata.</param>
-    /// <param name="iosMetadataFileName">The path to the file containing the IO pin configuration.</param>
-    public FirmwareGenerator(string registerMetadataFileName, string iosMetadataFileName)
+    /// <param name="deviceMetadata">The device metadata object.</param>
+    /// <param name="portPinMetadata">The IO pin configuration map.</param>
+    public FirmwareGenerator(DeviceInfo deviceMetadata, Dictionary<string, PortPinInfo> portPinMetadata)
     {
         var session = new Dictionary<string, object>
         {
-            { "RegisterMetadataPath", Path.GetFullPath(registerMetadataFileName) },
-            { "IOMetadataPath", Path.GetFullPath(iosMetadataFileName) }
+            { "DeviceMetadata", deviceMetadata },
+            { "PortPinMetadata", portPinMetadata }
         };
         _appTemplate.Session = session;
         _appImplTemplate.Session = session;

--- a/src/InterfaceGenerator.cs
+++ b/src/InterfaceGenerator.cs
@@ -14,16 +14,16 @@ public sealed class InterfaceGenerator
 
     /// <summary>
     /// Initializes a new instance of the <see cref="InterfaceGenerator"/> class with the
-    /// specified path to the device metadata file and target namespace for generated code.
+    /// specified device metadata and target namespace for generated code.
     /// </summary>
-    /// <param name="metadataFileName">The path to the file containing the device metadata.</param>
+    /// <param name="deviceMetadata">The device metadata object.</param>
     /// <param name="ns">The target namespace to use for all generated code.</param>
-    public InterfaceGenerator(string metadataFileName, string ns)
+    public InterfaceGenerator(DeviceInfo deviceMetadata, string ns)
     {
         var session = new Dictionary<string, object>
         {
             { "Namespace", ns },
-            { "MetadataPath", Path.GetFullPath(metadataFileName) }
+            { "DeviceMetadata", deviceMetadata }
         };
         _deviceTemplate.Session = session;
         _asyncDeviceTemplate.Session = session;

--- a/src/Interrupts.tt
+++ b/src/Interrupts.tt
@@ -1,6 +1,5 @@
 <#@ template debug="true" hostspecific="false" visibility="internal" language="C#" inherits="TemplateBase" #>
-<#@ parameter name="RegisterMetadataPath" type="string" #>
-<#@ parameter name="IOMetadataPath" type="string" #>
+<#@ parameter name="PortPinMetadata" type="Dictionary<string, PortPinInfo>" #>
 <#@ import namespace="Harp.Generators" #>
 <#@ import namespace="System.IO" #>
 <#@ import namespace="System.Linq" #>
@@ -18,9 +17,7 @@
 /************************************************************************/
 extern AppRegs app_regs;
 <#
-var deviceMetadata = TemplateHelper.ReadDeviceMetadata(RegisterMetadataPath);
-var portPinMetadata = TemplateHelper.ReadPortPinMetadata(IOMetadataPath);
-var interruptPins = TemplateHelper.GetPortPinsOfType<InputPinInfo>(portPinMetadata)
+var interruptPins = TemplateHelper.GetPortPinsOfType<InputPinInfo>(PortPinMetadata)
                                   .Where(pin => pin.Value.InterruptPriority != InterruptPriority.Off)
                                   .ToList();
 #>

--- a/tests/FirmwareGeneratorTests.cs
+++ b/tests/FirmwareGeneratorTests.cs
@@ -21,7 +21,9 @@ public sealed class FirmwareGeneratorTests
     {
         metadataFileName = TestHelper.GetMetadataPath(metadataFileName);
         var iosMetadataFileName = Path.ChangeExtension(metadataFileName, ".ios.yml");
-        var generator = new FirmwareGenerator(metadataFileName, iosMetadataFileName);
+        var deviceMetadata = TestHelper.ReadDeviceMetadata(metadataFileName);
+        var portPinMetadata = TestHelper.ReadPortPinMetadata(iosMetadataFileName);
+        var generator = new FirmwareGenerator(deviceMetadata, portPinMetadata);
         var headers = generator.GenerateHeaders();
         var implementation = generator.GenerateImplementation();
 

--- a/tests/InterfaceGeneratorTests.cs
+++ b/tests/InterfaceGeneratorTests.cs
@@ -23,7 +23,8 @@ public sealed class InterfaceGeneratorTests
     public void DeviceTemplate_GenerateAndBuildWithoutErrors(string metadataFileName)
     {
         metadataFileName = TestHelper.GetMetadataPath(metadataFileName);
-        var generator = new InterfaceGenerator(metadataFileName, typeof(InterfaceGeneratorTests).Namespace);
+        var deviceMetadata = TestHelper.ReadDeviceMetadata(metadataFileName);
+        var generator = new InterfaceGenerator(deviceMetadata, typeof(InterfaceGeneratorTests).Namespace);
         var implementation = generator.GenerateImplementation();
         var outputFileName = $"{Path.GetFileNameWithoutExtension(metadataFileName)}.cs";
         var customImplementation = TestHelper.GetManifestResourceText($"EmbeddedSources.{outputFileName}");

--- a/tests/TestHelper.cs
+++ b/tests/TestHelper.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using YamlDotNet.Core;
 
 namespace Harp.Generators.Tests;
 
@@ -24,6 +25,19 @@ static class TestHelper
     public static string GetMetadataPath(string fileName)
     {
         return Path.Combine("Metadata", fileName);
+    }
+
+    public static DeviceInfo ReadDeviceMetadata(string path)
+    {
+        using var reader = new StreamReader(path);
+        var parser = new MergingParser(new Parser(reader));
+        return MetadataDeserializer.Instance.Deserialize<DeviceInfo>(parser);
+    }
+
+    public static Dictionary<string, PortPinInfo> ReadPortPinMetadata(string path)
+    {
+        using var reader = new StreamReader(path);
+        return MetadataDeserializer.Instance.Deserialize<Dictionary<string, PortPinInfo>>(reader);
     }
 
     public static void AssertExpectedOutput(string actual, string outputFileName)


### PR DESCRIPTION
This avoids file access during template processing and provides more flexibility for in-memory code generation using objects rather than requiring external files.

It also avoids accessing the same metadata files multiple times during template processing.