### PR TITLE
Ignore member offset if register length is zero

### DIFF
--- a/src/Interface.cs
+++ b/src/Interface.cs
@@ -584,9 +584,9 @@ internal static partial class TemplateHelper
             else
                 expression = $"PayloadMarshal.GetSubArray({expression}, {memberOffset}, {memberLength})";
         }
-        else if (member.Offset.HasValue)
+        else if (register.Length > 0 && member.Offset.HasValue)
         {
-            expression = $"{expression}[{member.Offset.GetValueOrDefault()}]";
+            expression = $"{expression}[{memberOffset}]";
         }
         if (member.Mask.HasValue)
         {
@@ -642,7 +642,7 @@ internal static partial class TemplateHelper
             }
             else
                 memberConversion = $" = {memberConversion}";
-            var memberIndexer = member.Offset.HasValue ? $"[{memberOffset}]" : string.Empty;
+            var memberIndexer = register.Length > 0 && member.Offset.HasValue ? $"[{memberOffset}]" : string.Empty;
             return $"{expression}{memberIndexer}{memberConversion}";
         }
     }

--- a/tests/ExpectedOutput/device.app_funcs.c
+++ b/tests/ExpectedOutput/device.app_funcs.c
@@ -20,7 +20,9 @@ void (*app_func_rd_pointer[])(void) = {
 	&app_read_REG_COUNTER0,
 	&app_read_REG_PORT_DIO_SET,
 	&app_read_REG_PULSE_DO_PORT0,
-	&app_read_REG_PULSE_DO0
+	&app_read_REG_PULSE_DO0,
+	&app_read_REG_START_PULSE,
+	&app_read_REG_START_PULSE_TRAIN
 };
 
 bool (*app_func_wr_pointer[])(void*) = {
@@ -35,7 +37,9 @@ bool (*app_func_wr_pointer[])(void*) = {
 	&app_write_REG_COUNTER0,
 	&app_write_REG_PORT_DIO_SET,
 	&app_write_REG_PULSE_DO_PORT0,
-	&app_write_REG_PULSE_DO0
+	&app_write_REG_PULSE_DO0,
+	&app_write_REG_START_PULSE,
+	&app_write_REG_START_PULSE_TRAIN
 };
 
 /************************************************************************/
@@ -203,5 +207,40 @@ bool app_write_REG_PULSE_DO0(void *a)
 	uint16_t reg = *((uint16_t*)a);
 
 	app_regs.REG_PULSE_DO0 = reg;
+    return true;
+}
+
+/************************************************************************/
+/* REG_START_PULSE                                                      */
+/************************************************************************/
+void app_read_REG_START_PULSE(void)
+{
+	//app_regs.REG_START_PULSE = 0;
+
+}
+
+bool app_write_REG_START_PULSE(void *a)
+{
+	uint16_t reg = *((uint16_t*)a);
+
+	app_regs.REG_START_PULSE = reg;
+    return true;
+}
+
+/************************************************************************/
+/* REG_START_PULSE_TRAIN                                                */
+/************************************************************************/
+// This register is an array with 2 positions
+void app_read_REG_START_PULSE_TRAIN(void)
+{
+	//app_regs.REG_START_PULSE_TRAIN[0] = 0;
+
+}
+
+bool app_write_REG_START_PULSE_TRAIN(void *a)
+{
+	uint16_t *reg = ((uint16_t*)a);
+
+	app_regs.REG_START_PULSE_TRAIN[0] = reg[0];
     return true;
 }

--- a/tests/ExpectedOutput/device.app_funcs.h
+++ b/tests/ExpectedOutput/device.app_funcs.h
@@ -32,6 +32,8 @@ void app_read_REG_COUNTER0(void);
 void app_read_REG_PORT_DIO_SET(void);
 void app_read_REG_PULSE_DO_PORT0(void);
 void app_read_REG_PULSE_DO0(void);
+void app_read_REG_START_PULSE(void);
+void app_read_REG_START_PULSE_TRAIN(void);
 
 bool app_write_REG_DIGITAL_INPUTS(void *a);
 bool app_write_REG_ANALOG_DATA(void *a);
@@ -45,6 +47,8 @@ bool app_write_REG_COUNTER0(void *a);
 bool app_write_REG_PORT_DIO_SET(void *a);
 bool app_write_REG_PULSE_DO_PORT0(void *a);
 bool app_write_REG_PULSE_DO0(void *a);
+bool app_write_REG_START_PULSE(void *a);
+bool app_write_REG_START_PULSE_TRAIN(void *a);
 
 
 #endif /* _APP_FUNCTIONS_H_ */

--- a/tests/ExpectedOutput/device.app_ios_and_regs.c
+++ b/tests/ExpectedOutput/device.app_ios_and_regs.c
@@ -73,6 +73,8 @@ uint8_t app_regs_type[] = {
     TYPE_I32,
     TYPE_U8,
     TYPE_U16,
+    TYPE_U16,
+    TYPE_U16,
     TYPE_U16
 };
 
@@ -88,7 +90,9 @@ uint16_t app_regs_n_elements[] = {
     1,
     1,
     1,
-    1
+    1,
+    1,
+    2
 };
 
 uint8_t *app_regs_pointer[] = {
@@ -103,5 +107,7 @@ uint8_t *app_regs_pointer[] = {
     (uint8_t*)(&app_regs.REG_COUNTER0),
     (uint8_t*)(&app_regs.REG_PORT_DIO_SET),
     (uint8_t*)(&app_regs.REG_PULSE_DO_PORT0),
-    (uint8_t*)(&app_regs.REG_PULSE_DO0)
+    (uint8_t*)(&app_regs.REG_PULSE_DO0),
+    (uint8_t*)(&app_regs.REG_START_PULSE),
+    (uint8_t*)(&app_regs.REG_START_PULSE_TRAIN)
 };

--- a/tests/ExpectedOutput/device.app_ios_and_regs.h
+++ b/tests/ExpectedOutput/device.app_ios_and_regs.h
@@ -136,6 +136,8 @@ typedef struct
     uint8_t REG_PORT_DIO_SET;
     uint16_t REG_PULSE_DO_PORT0;
     uint16_t REG_PULSE_DO0;
+    uint16_t REG_START_PULSE;
+    uint16_t REG_START_PULSE_TRAIN[2];
 } AppRegs;
 
 /************************************************************************/
@@ -154,6 +156,8 @@ typedef struct
 #define ADD_REG_PORT_DIO_SET               41 // U8     
 #define ADD_REG_PULSE_DO_PORT0             42 // U16    
 #define ADD_REG_PULSE_DO0                  43 // U16    
+#define ADD_REG_START_PULSE                37 // U16    
+#define ADD_REG_START_PULSE_TRAIN          38 // U16    
 
 /************************************************************************/
 /* Tests registers' memory limits                                       */
@@ -164,7 +168,7 @@ typedef struct
 /* Memory limits */
 #define APP_REGS_ADD_MIN                    0x20
 #define APP_REGS_ADD_MAX                    0x2B
-#define APP_NBYTES_OF_REG_BANK              111
+#define APP_NBYTES_OF_REG_BANK              117
 
 /************************************************************************/
 /* Registers' bits                                                      */

--- a/tests/ExpectedOutput/device.cs
+++ b/tests/ExpectedOutput/device.cs
@@ -48,7 +48,9 @@ namespace Harp.Generators.Tests
             { 40, typeof(Counter0) },
             { 41, typeof(PortDIOSet) },
             { 42, typeof(PulseDOPort0) },
-            { 43, typeof(PulseDO0) }
+            { 43, typeof(PulseDO0) },
+            { 37, typeof(StartPulse) },
+            { 38, typeof(StartPulseTrain) }
         };
 
         /// <summary>
@@ -275,6 +277,8 @@ namespace Harp.Generators.Tests
     /// <seealso cref="PortDIOSet"/>
     /// <seealso cref="PulseDOPort0"/>
     /// <seealso cref="PulseDO0"/>
+    /// <seealso cref="StartPulse"/>
+    /// <seealso cref="StartPulseTrain"/>
     [XmlInclude(typeof(DigitalInputs))]
     [XmlInclude(typeof(AnalogData))]
     [XmlInclude(typeof(ComplexConfiguration))]
@@ -287,6 +291,8 @@ namespace Harp.Generators.Tests
     [XmlInclude(typeof(PortDIOSet))]
     [XmlInclude(typeof(PulseDOPort0))]
     [XmlInclude(typeof(PulseDO0))]
+    [XmlInclude(typeof(StartPulse))]
+    [XmlInclude(typeof(StartPulseTrain))]
     [Description("Filters register-specific messages reported by the Tests device.")]
     public class FilterRegister : FilterRegisterBuilder, INamedElement
     {
@@ -320,6 +326,8 @@ namespace Harp.Generators.Tests
     /// <seealso cref="PortDIOSet"/>
     /// <seealso cref="PulseDOPort0"/>
     /// <seealso cref="PulseDO0"/>
+    /// <seealso cref="StartPulse"/>
+    /// <seealso cref="StartPulseTrain"/>
     [XmlInclude(typeof(DigitalInputs))]
     [XmlInclude(typeof(AnalogData))]
     [XmlInclude(typeof(ComplexConfiguration))]
@@ -332,6 +340,8 @@ namespace Harp.Generators.Tests
     [XmlInclude(typeof(PortDIOSet))]
     [XmlInclude(typeof(PulseDOPort0))]
     [XmlInclude(typeof(PulseDO0))]
+    [XmlInclude(typeof(StartPulse))]
+    [XmlInclude(typeof(StartPulseTrain))]
     [XmlInclude(typeof(TimestampedDigitalInputs))]
     [XmlInclude(typeof(TimestampedAnalogData))]
     [XmlInclude(typeof(TimestampedComplexConfiguration))]
@@ -344,6 +354,8 @@ namespace Harp.Generators.Tests
     [XmlInclude(typeof(TimestampedPortDIOSet))]
     [XmlInclude(typeof(TimestampedPulseDOPort0))]
     [XmlInclude(typeof(TimestampedPulseDO0))]
+    [XmlInclude(typeof(TimestampedStartPulse))]
+    [XmlInclude(typeof(TimestampedStartPulseTrain))]
     [Description("Filters and selects specific messages reported by the Tests device.")]
     public partial class Parse : ParseBuilder, INamedElement
     {
@@ -374,6 +386,8 @@ namespace Harp.Generators.Tests
     /// <seealso cref="PortDIOSet"/>
     /// <seealso cref="PulseDOPort0"/>
     /// <seealso cref="PulseDO0"/>
+    /// <seealso cref="StartPulse"/>
+    /// <seealso cref="StartPulseTrain"/>
     [XmlInclude(typeof(DigitalInputs))]
     [XmlInclude(typeof(AnalogData))]
     [XmlInclude(typeof(ComplexConfiguration))]
@@ -386,6 +400,8 @@ namespace Harp.Generators.Tests
     [XmlInclude(typeof(PortDIOSet))]
     [XmlInclude(typeof(PulseDOPort0))]
     [XmlInclude(typeof(PulseDO0))]
+    [XmlInclude(typeof(StartPulse))]
+    [XmlInclude(typeof(StartPulseTrain))]
     [Description("Formats a sequence of values as specific Tests register messages.")]
     public partial class Format : FormatBuilder, INamedElement
     {
@@ -1677,6 +1693,237 @@ namespace Harp.Generators.Tests
     }
 
     /// <summary>
+    /// Represents a register that manipulates messages from register StartPulse.
+    /// </summary>
+    [Description("")]
+    public partial class StartPulse
+    {
+        /// <summary>
+        /// Represents the address of the <see cref="StartPulse"/> register. This field is constant.
+        /// </summary>
+        public const int Address = 37;
+
+        /// <summary>
+        /// Represents the payload type of the <see cref="StartPulse"/> register. This field is constant.
+        /// </summary>
+        public const PayloadType RegisterType = PayloadType.U16;
+
+        /// <summary>
+        /// Represents the length of the <see cref="StartPulse"/> register. This field is constant.
+        /// </summary>
+        public const int RegisterLength = 1;
+
+        static StartPulsePayload ParsePayload(ushort payload)
+        {
+            StartPulsePayload result;
+            result.DigitalOutput = (PwmPort)(ushort)((payload & 0xC00) >> 10);
+            result.PulseWidth = (ushort)(ushort)(payload & 0x3FF);
+            return result;
+        }
+
+        static ushort FormatPayload(StartPulsePayload value)
+        {
+            ushort result;
+            result = (ushort)(((ushort)value.DigitalOutput << 10) & 0xC00);
+            result |= (ushort)((ushort)value.PulseWidth & 0x3FF);
+            return result;
+        }
+
+        /// <summary>
+        /// Returns the payload data for <see cref="StartPulse"/> register messages.
+        /// </summary>
+        /// <param name="message">A <see cref="HarpMessage"/> object representing the register message.</param>
+        /// <returns>A value representing the message payload.</returns>
+        public static StartPulsePayload GetPayload(HarpMessage message)
+        {
+            return ParsePayload(message.GetPayloadUInt16());
+        }
+
+        /// <summary>
+        /// Returns the timestamped payload data for <see cref="StartPulse"/> register messages.
+        /// </summary>
+        /// <param name="message">A <see cref="HarpMessage"/> object representing the register message.</param>
+        /// <returns>A value representing the timestamped message payload.</returns>
+        public static Timestamped<StartPulsePayload> GetTimestampedPayload(HarpMessage message)
+        {
+            var payload = message.GetTimestampedPayloadUInt16();
+            return Timestamped.Create(ParsePayload(payload.Value), payload.Seconds);
+        }
+
+        /// <summary>
+        /// Returns a Harp message for the <see cref="StartPulse"/> register.
+        /// </summary>
+        /// <param name="messageType">The type of the Harp message.</param>
+        /// <param name="value">The value to be stored in the message payload.</param>
+        /// <returns>
+        /// A <see cref="HarpMessage"/> object for the <see cref="StartPulse"/> register
+        /// with the specified message type and payload.
+        /// </returns>
+        public static HarpMessage FromPayload(MessageType messageType, StartPulsePayload value)
+        {
+            return HarpMessage.FromUInt16(Address, messageType, FormatPayload(value));
+        }
+
+        /// <summary>
+        /// Returns a timestamped Harp message for the <see cref="StartPulse"/>
+        /// register.
+        /// </summary>
+        /// <param name="timestamp">The timestamp of the message payload, in seconds.</param>
+        /// <param name="messageType">The type of the Harp message.</param>
+        /// <param name="value">The value to be stored in the message payload.</param>
+        /// <returns>
+        /// A <see cref="HarpMessage"/> object for the <see cref="StartPulse"/> register
+        /// with the specified message type, timestamp, and payload.
+        /// </returns>
+        public static HarpMessage FromPayload(double timestamp, MessageType messageType, StartPulsePayload value)
+        {
+            return HarpMessage.FromUInt16(Address, timestamp, messageType, FormatPayload(value));
+        }
+    }
+
+    /// <summary>
+    /// Provides methods for manipulating timestamped messages from the
+    /// StartPulse register.
+    /// </summary>
+    /// <seealso cref="StartPulse"/>
+    [Description("Filters and selects timestamped messages from the StartPulse register.")]
+    public partial class TimestampedStartPulse
+    {
+        /// <summary>
+        /// Represents the address of the <see cref="StartPulse"/> register. This field is constant.
+        /// </summary>
+        public const int Address = StartPulse.Address;
+
+        /// <summary>
+        /// Returns timestamped payload data for <see cref="StartPulse"/> register messages.
+        /// </summary>
+        /// <param name="message">A <see cref="HarpMessage"/> object representing the register message.</param>
+        /// <returns>A value representing the timestamped message payload.</returns>
+        public static Timestamped<StartPulsePayload> GetPayload(HarpMessage message)
+        {
+            return StartPulse.GetTimestampedPayload(message);
+        }
+    }
+
+    /// <summary>
+    /// Represents a register that manipulates messages from register StartPulseTrain.
+    /// </summary>
+    [Description("")]
+    public partial class StartPulseTrain
+    {
+        /// <summary>
+        /// Represents the address of the <see cref="StartPulseTrain"/> register. This field is constant.
+        /// </summary>
+        public const int Address = 38;
+
+        /// <summary>
+        /// Represents the payload type of the <see cref="StartPulseTrain"/> register. This field is constant.
+        /// </summary>
+        public const PayloadType RegisterType = PayloadType.U16;
+
+        /// <summary>
+        /// Represents the length of the <see cref="StartPulseTrain"/> register. This field is constant.
+        /// </summary>
+        public const int RegisterLength = 2;
+
+        static StartPulseTrainPayload ParsePayload(ushort[] payload)
+        {
+            StartPulseTrainPayload result;
+            result.DigitalOutput = (PwmPort)(ushort)((payload[0] & 0xC00) >> 10);
+            result.PulseWidth = (ushort)(ushort)(payload[0] & 0x3FF);
+            result.Frequency = (byte)(ushort)((payload[1] & 0xFF00) >> 8);
+            result.PulseCount = (byte)(ushort)(payload[1] & 0xFF);
+            return result;
+        }
+
+        static ushort[] FormatPayload(StartPulseTrainPayload value)
+        {
+            ushort[] result;
+            result = new ushort[2];
+            result[0] = (ushort)(((ushort)value.DigitalOutput << 10) & 0xC00);
+            result[0] |= (ushort)((ushort)value.PulseWidth & 0x3FF);
+            result[1] = (ushort)(((ushort)value.Frequency << 8) & 0xFF00);
+            result[1] |= (ushort)((ushort)value.PulseCount & 0xFF);
+            return result;
+        }
+
+        /// <summary>
+        /// Returns the payload data for <see cref="StartPulseTrain"/> register messages.
+        /// </summary>
+        /// <param name="message">A <see cref="HarpMessage"/> object representing the register message.</param>
+        /// <returns>A value representing the message payload.</returns>
+        public static StartPulseTrainPayload GetPayload(HarpMessage message)
+        {
+            return ParsePayload(message.GetPayloadArray<ushort>());
+        }
+
+        /// <summary>
+        /// Returns the timestamped payload data for <see cref="StartPulseTrain"/> register messages.
+        /// </summary>
+        /// <param name="message">A <see cref="HarpMessage"/> object representing the register message.</param>
+        /// <returns>A value representing the timestamped message payload.</returns>
+        public static Timestamped<StartPulseTrainPayload> GetTimestampedPayload(HarpMessage message)
+        {
+            var payload = message.GetTimestampedPayloadArray<ushort>();
+            return Timestamped.Create(ParsePayload(payload.Value), payload.Seconds);
+        }
+
+        /// <summary>
+        /// Returns a Harp message for the <see cref="StartPulseTrain"/> register.
+        /// </summary>
+        /// <param name="messageType">The type of the Harp message.</param>
+        /// <param name="value">The value to be stored in the message payload.</param>
+        /// <returns>
+        /// A <see cref="HarpMessage"/> object for the <see cref="StartPulseTrain"/> register
+        /// with the specified message type and payload.
+        /// </returns>
+        public static HarpMessage FromPayload(MessageType messageType, StartPulseTrainPayload value)
+        {
+            return HarpMessage.FromUInt16(Address, messageType, FormatPayload(value));
+        }
+
+        /// <summary>
+        /// Returns a timestamped Harp message for the <see cref="StartPulseTrain"/>
+        /// register.
+        /// </summary>
+        /// <param name="timestamp">The timestamp of the message payload, in seconds.</param>
+        /// <param name="messageType">The type of the Harp message.</param>
+        /// <param name="value">The value to be stored in the message payload.</param>
+        /// <returns>
+        /// A <see cref="HarpMessage"/> object for the <see cref="StartPulseTrain"/> register
+        /// with the specified message type, timestamp, and payload.
+        /// </returns>
+        public static HarpMessage FromPayload(double timestamp, MessageType messageType, StartPulseTrainPayload value)
+        {
+            return HarpMessage.FromUInt16(Address, timestamp, messageType, FormatPayload(value));
+        }
+    }
+
+    /// <summary>
+    /// Provides methods for manipulating timestamped messages from the
+    /// StartPulseTrain register.
+    /// </summary>
+    /// <seealso cref="StartPulseTrain"/>
+    [Description("Filters and selects timestamped messages from the StartPulseTrain register.")]
+    public partial class TimestampedStartPulseTrain
+    {
+        /// <summary>
+        /// Represents the address of the <see cref="StartPulseTrain"/> register. This field is constant.
+        /// </summary>
+        public const int Address = StartPulseTrain.Address;
+
+        /// <summary>
+        /// Returns timestamped payload data for <see cref="StartPulseTrain"/> register messages.
+        /// </summary>
+        /// <param name="message">A <see cref="HarpMessage"/> object representing the register message.</param>
+        /// <returns>A value representing the timestamped message payload.</returns>
+        public static Timestamped<StartPulseTrainPayload> GetPayload(HarpMessage message)
+        {
+            return StartPulseTrain.GetTimestampedPayload(message);
+        }
+    }
+
+    /// <summary>
     /// Represents an operator which creates standard message payloads for the
     /// Tests device.
     /// </summary>
@@ -1692,6 +1939,8 @@ namespace Harp.Generators.Tests
     /// <seealso cref="CreatePortDIOSetPayload"/>
     /// <seealso cref="CreatePulseDOPort0Payload"/>
     /// <seealso cref="CreatePulseDO0Payload"/>
+    /// <seealso cref="CreateStartPulsePayload"/>
+    /// <seealso cref="CreateStartPulseTrainPayload"/>
     [XmlInclude(typeof(CreateDigitalInputsPayload))]
     [XmlInclude(typeof(CreateAnalogDataPayload))]
     [XmlInclude(typeof(CreateComplexConfigurationPayload))]
@@ -1704,6 +1953,8 @@ namespace Harp.Generators.Tests
     [XmlInclude(typeof(CreatePortDIOSetPayload))]
     [XmlInclude(typeof(CreatePulseDOPort0Payload))]
     [XmlInclude(typeof(CreatePulseDO0Payload))]
+    [XmlInclude(typeof(CreateStartPulsePayload))]
+    [XmlInclude(typeof(CreateStartPulseTrainPayload))]
     [XmlInclude(typeof(CreateTimestampedDigitalInputsPayload))]
     [XmlInclude(typeof(CreateTimestampedAnalogDataPayload))]
     [XmlInclude(typeof(CreateTimestampedComplexConfigurationPayload))]
@@ -1716,6 +1967,8 @@ namespace Harp.Generators.Tests
     [XmlInclude(typeof(CreateTimestampedPortDIOSetPayload))]
     [XmlInclude(typeof(CreateTimestampedPulseDOPort0Payload))]
     [XmlInclude(typeof(CreateTimestampedPulseDO0Payload))]
+    [XmlInclude(typeof(CreateTimestampedStartPulsePayload))]
+    [XmlInclude(typeof(CreateTimestampedStartPulseTrainPayload))]
     [Description("Creates standard message payloads for the Tests device.")]
     public partial class CreateMessage : CreateMessageBuilder, INamedElement
     {
@@ -2484,6 +2737,148 @@ namespace Harp.Generators.Tests
     }
 
     /// <summary>
+    /// Represents an operator that creates a message payload
+    /// for register StartPulse.
+    /// </summary>
+    [DisplayName("StartPulsePayload")]
+    [Description("Creates a message payload for register StartPulse.")]
+    public partial class CreateStartPulsePayload
+    {
+        /// <summary>
+        /// Gets or sets a value to write on payload member DigitalOutput.
+        /// </summary>
+        [Description("")]
+        public PwmPort DigitalOutput { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value to write on payload member PulseWidth.
+        /// </summary>
+        [Description("")]
+        public ushort PulseWidth { get; set; }
+
+        /// <summary>
+        /// Creates a message payload for the StartPulse register.
+        /// </summary>
+        /// <returns>The created message payload value.</returns>
+        public StartPulsePayload GetPayload()
+        {
+            StartPulsePayload value;
+            value.DigitalOutput = DigitalOutput;
+            value.PulseWidth = PulseWidth;
+            return value;
+        }
+
+        /// <summary>
+        /// Creates a message for register StartPulse.
+        /// </summary>
+        /// <param name="messageType">Specifies the type of the created message.</param>
+        /// <returns>A new message for the StartPulse register.</returns>
+        public HarpMessage GetMessage(MessageType messageType)
+        {
+            return Harp.Generators.Tests.StartPulse.FromPayload(messageType, GetPayload());
+        }
+    }
+
+    /// <summary>
+    /// Represents an operator that creates a timestamped message payload
+    /// for register StartPulse.
+    /// </summary>
+    [DisplayName("TimestampedStartPulsePayload")]
+    [Description("Creates a timestamped message payload for register StartPulse.")]
+    public partial class CreateTimestampedStartPulsePayload : CreateStartPulsePayload
+    {
+        /// <summary>
+        /// Creates a timestamped message for register StartPulse.
+        /// </summary>
+        /// <param name="timestamp">The timestamp of the message payload, in seconds.</param>
+        /// <param name="messageType">Specifies the type of the created message.</param>
+        /// <returns>A new timestamped message for the StartPulse register.</returns>
+        public HarpMessage GetMessage(double timestamp, MessageType messageType)
+        {
+            return Harp.Generators.Tests.StartPulse.FromPayload(timestamp, messageType, GetPayload());
+        }
+    }
+
+    /// <summary>
+    /// Represents an operator that creates a message payload
+    /// for register StartPulseTrain.
+    /// </summary>
+    [DisplayName("StartPulseTrainPayload")]
+    [Description("Creates a message payload for register StartPulseTrain.")]
+    public partial class CreateStartPulseTrainPayload
+    {
+        /// <summary>
+        /// Gets or sets a value to write on payload member DigitalOutput.
+        /// </summary>
+        [Description("")]
+        public PwmPort DigitalOutput { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value to write on payload member PulseWidth.
+        /// </summary>
+        [Description("")]
+        public ushort PulseWidth { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value to write on payload member Frequency.
+        /// </summary>
+        [Range(min: 1, max: 255)]
+        [Editor(DesignTypes.NumericUpDownEditor, DesignTypes.UITypeEditor)]
+        [Description("")]
+        public byte Frequency { get; set; } = 1;
+
+        /// <summary>
+        /// Gets or sets a value to write on payload member PulseCount.
+        /// </summary>
+        [Description("")]
+        public byte PulseCount { get; set; }
+
+        /// <summary>
+        /// Creates a message payload for the StartPulseTrain register.
+        /// </summary>
+        /// <returns>The created message payload value.</returns>
+        public StartPulseTrainPayload GetPayload()
+        {
+            StartPulseTrainPayload value;
+            value.DigitalOutput = DigitalOutput;
+            value.PulseWidth = PulseWidth;
+            value.Frequency = Frequency;
+            value.PulseCount = PulseCount;
+            return value;
+        }
+
+        /// <summary>
+        /// Creates a message for register StartPulseTrain.
+        /// </summary>
+        /// <param name="messageType">Specifies the type of the created message.</param>
+        /// <returns>A new message for the StartPulseTrain register.</returns>
+        public HarpMessage GetMessage(MessageType messageType)
+        {
+            return Harp.Generators.Tests.StartPulseTrain.FromPayload(messageType, GetPayload());
+        }
+    }
+
+    /// <summary>
+    /// Represents an operator that creates a timestamped message payload
+    /// for register StartPulseTrain.
+    /// </summary>
+    [DisplayName("TimestampedStartPulseTrainPayload")]
+    [Description("Creates a timestamped message payload for register StartPulseTrain.")]
+    public partial class CreateTimestampedStartPulseTrainPayload : CreateStartPulseTrainPayload
+    {
+        /// <summary>
+        /// Creates a timestamped message for register StartPulseTrain.
+        /// </summary>
+        /// <param name="timestamp">The timestamp of the message payload, in seconds.</param>
+        /// <param name="messageType">Specifies the type of the created message.</param>
+        /// <returns>A new timestamped message for the StartPulseTrain register.</returns>
+        public HarpMessage GetMessage(double timestamp, MessageType messageType)
+        {
+            return Harp.Generators.Tests.StartPulseTrain.FromPayload(timestamp, messageType, GetPayload());
+        }
+    }
+
+    /// <summary>
     /// Represents the payload of the AnalogData register.
     /// </summary>
     public struct AnalogDataPayload
@@ -2776,6 +3171,114 @@ namespace Harp.Generators.Tests
             return "BitmaskSplitterPayload { " +
                 "Low = " + Low + ", " +
                 "High = " + High + " " +
+            "}";
+        }
+    }
+
+    /// <summary>
+    /// Represents the payload of the StartPulse register.
+    /// </summary>
+    public struct StartPulsePayload
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="StartPulsePayload"/> structure.
+        /// </summary>
+        /// <param name="digitalOutput"></param>
+        /// <param name="pulseWidth"></param>
+        public StartPulsePayload(
+            PwmPort digitalOutput,
+            ushort pulseWidth)
+        {
+            DigitalOutput = digitalOutput;
+            PulseWidth = pulseWidth;
+        }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        public PwmPort DigitalOutput;
+
+        /// <summary>
+        /// 
+        /// </summary>
+        public ushort PulseWidth;
+
+        /// <summary>
+        /// Returns a <see cref="string"/> that represents the payload of
+        /// the StartPulse register.
+        /// </summary>
+        /// <returns>
+        /// A <see cref="string"/> that represents the payload of the
+        /// StartPulse register.
+        /// </returns>
+        public override string ToString()
+        {
+            return "StartPulsePayload { " +
+                "DigitalOutput = " + DigitalOutput + ", " +
+                "PulseWidth = " + PulseWidth + " " +
+            "}";
+        }
+    }
+
+    /// <summary>
+    /// Represents the payload of the StartPulseTrain register.
+    /// </summary>
+    public struct StartPulseTrainPayload
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="StartPulseTrainPayload"/> structure.
+        /// </summary>
+        /// <param name="digitalOutput"></param>
+        /// <param name="pulseWidth"></param>
+        /// <param name="frequency"></param>
+        /// <param name="pulseCount"></param>
+        public StartPulseTrainPayload(
+            PwmPort digitalOutput,
+            ushort pulseWidth,
+            byte frequency,
+            byte pulseCount)
+        {
+            DigitalOutput = digitalOutput;
+            PulseWidth = pulseWidth;
+            Frequency = frequency;
+            PulseCount = pulseCount;
+        }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        public PwmPort DigitalOutput;
+
+        /// <summary>
+        /// 
+        /// </summary>
+        public ushort PulseWidth;
+
+        /// <summary>
+        /// 
+        /// </summary>
+        public byte Frequency;
+
+        /// <summary>
+        /// 
+        /// </summary>
+        public byte PulseCount;
+
+        /// <summary>
+        /// Returns a <see cref="string"/> that represents the payload of
+        /// the StartPulseTrain register.
+        /// </summary>
+        /// <returns>
+        /// A <see cref="string"/> that represents the payload of the
+        /// StartPulseTrain register.
+        /// </returns>
+        public override string ToString()
+        {
+            return "StartPulseTrainPayload { " +
+                "DigitalOutput = " + DigitalOutput + ", " +
+                "PulseWidth = " + PulseWidth + ", " +
+                "Frequency = " + Frequency + ", " +
+                "PulseCount = " + PulseCount + " " +
             "}";
         }
     }

--- a/tests/Metadata/device.yml
+++ b/tests/Metadata/device.yml
@@ -127,6 +127,37 @@ registers:
   PulseDO0:
     <<: *pulseDO
     address: 43
+  StartPulse:
+    address: 37
+    type: U16
+    access: Write
+    payloadSpec: &startPulse
+      DigitalOutput:
+        offset: 0
+        mask: 0xC00
+        maskType: PwmPort
+      PulseWidth:
+        offset: 0
+        mask: 0x3FF
+        interfaceType: ushort
+  StartPulseTrain:
+    address: 38
+    type: U16
+    length: 2
+    access: Write
+    payloadSpec:
+      <<: *startPulse
+      Frequency:
+        offset: 1
+        mask: 0xFF00
+        minValue: 1
+        maxValue: 255
+        defaultValue: 1
+        interfaceType: byte
+      PulseCount:
+        offset: 1
+        mask: 0xFF
+        interfaceType: byte
 bitMasks:
   PortDigitalIOS:
     bits:


### PR DESCRIPTION
In this case we cannot use an indexer since the payload is not an array.

Fixes #77 