### PR TITLE
Move device identifiers to app header and initialize core protocol V2

### DIFF
--- a/src/App.tt
+++ b/src/App.tt
@@ -9,6 +9,13 @@
 
 
 /************************************************************************/
+/* Define identifiers                                                   */
+/************************************************************************/
+#define DEVICE_NAME      "<#= DeviceMetadata.Device #>"
+#define WHO_AM_I         <#= DeviceMetadata.WhoAmI #>
+
+
+/************************************************************************/
 /* Define versions                                                      */
 /************************************************************************/
 #ifndef MAJOR_HW_VERSION
@@ -17,14 +24,17 @@
 #ifndef MINOR_HW_VERSION
 #define MINOR_HW_VERSION <#= DeviceMetadata.HardwareTargets.Minor #>
 #endif
+#ifndef PATCH_HW_VERSION
+#define PATCH_HW_VERSION 0
+#endif
 #ifndef MAJOR_FW_VERSION
 #define MAJOR_FW_VERSION <#= DeviceMetadata.FirmwareVersion.Major #>
 #endif
 #ifndef MINOR_FW_VERSION
 #define MINOR_FW_VERSION <#= DeviceMetadata.FirmwareVersion.Minor #>
 #endif
-#ifndef ASSEMBLY_VERSION
-#define ASSEMBLY_VERSION 0
+#ifndef PATCH_FW_VERSION
+#define PATCH_FW_VERSION 0
 #endif
 
 

--- a/src/AppImpl.tt
+++ b/src/AppImpl.tt
@@ -24,31 +24,23 @@ extern bool (*app_func_wr_pointer[])(void*);
 /************************************************************************/
 /* Initialize app                                                       */
 /************************************************************************/
-static const uint8_t default_device_name[] = "<#= DeviceMetadata.Device #>";
+static const uint8_t default_device_name[] = DEVICE_NAME;
 
 void hwbp_app_initialize(void)
-{
-    /* Define versions */
-    uint8_t hwH = MAJOR_HW_VERSION;
-    uint8_t hwL = MINOR_HW_VERSION;
-    uint8_t fwH = MAJOR_FW_VERSION;
-    uint8_t fwL = MINOR_FW_VERSION;
-    uint8_t ass = ASSEMBLY_VERSION;
-    
+{   
    	/* Start core */
-    core_func_start_core(
-        <#= DeviceMetadata.WhoAmI #>,
-        hwH, hwL,
-        fwH, fwL,
-        ass,
-        (uint8_t*)(&app_regs),
-        APP_NBYTES_OF_REG_BANK,
-        APP_REGS_ADD_MAX - APP_REGS_ADD_MIN + 1,
+   	core_func_start_core_V2(
+   	    WHO_AM_I,
+   	    MAJOR_HW_VERSION, MINOR_HW_VERSION, PATCH_HW_VERSION,
+   	    MAJOR_FW_VERSION, MINOR_FW_VERSION, PATCH_FW_VERSION,
+   	    (uint8_t*)(&app_regs),
+   	    APP_NBYTES_OF_REG_BANK,
+   	    APP_REGS_ADD_MAX - APP_REGS_ADD_MIN + 1,
    	    default_device_name,
    	    false,	// The device is _not_ able to repeat the harp timestamp clock
    	    false,	// The device is _not_ able to generate the harp timestamp clock
    	    0		// Default timestamp offset
-    );
+   	);
 }
 
 /************************************************************************/

--- a/tests/ExpectedOutput/device.app.c
+++ b/tests/ExpectedOutput/device.app.c
@@ -19,31 +19,23 @@ extern bool (*app_func_wr_pointer[])(void*);
 /************************************************************************/
 /* Initialize app                                                       */
 /************************************************************************/
-static const uint8_t default_device_name[] = "Tests";
+static const uint8_t default_device_name[] = DEVICE_NAME;
 
 void hwbp_app_initialize(void)
-{
-    /* Define versions */
-    uint8_t hwH = MAJOR_HW_VERSION;
-    uint8_t hwL = MINOR_HW_VERSION;
-    uint8_t fwH = MAJOR_FW_VERSION;
-    uint8_t fwL = MINOR_FW_VERSION;
-    uint8_t ass = ASSEMBLY_VERSION;
-    
+{   
    	/* Start core */
-    core_func_start_core(
-        0,
-        hwH, hwL,
-        fwH, fwL,
-        ass,
-        (uint8_t*)(&app_regs),
-        APP_NBYTES_OF_REG_BANK,
-        APP_REGS_ADD_MAX - APP_REGS_ADD_MIN + 1,
+   	core_func_start_core_V2(
+   	    WHO_AM_I,
+   	    MAJOR_HW_VERSION, MINOR_HW_VERSION, PATCH_HW_VERSION,
+   	    MAJOR_FW_VERSION, MINOR_FW_VERSION, PATCH_FW_VERSION,
+   	    (uint8_t*)(&app_regs),
+   	    APP_NBYTES_OF_REG_BANK,
+   	    APP_REGS_ADD_MAX - APP_REGS_ADD_MIN + 1,
    	    default_device_name,
    	    false,	// The device is _not_ able to repeat the harp timestamp clock
    	    false,	// The device is _not_ able to generate the harp timestamp clock
    	    0		// Default timestamp offset
-    );
+   	);
 }
 
 /************************************************************************/

--- a/tests/ExpectedOutput/device.app.h
+++ b/tests/ExpectedOutput/device.app.h
@@ -4,6 +4,13 @@
 
 
 /************************************************************************/
+/* Define identifiers                                                   */
+/************************************************************************/
+#define DEVICE_NAME      "Tests"
+#define WHO_AM_I         0
+
+
+/************************************************************************/
 /* Define versions                                                      */
 /************************************************************************/
 #ifndef MAJOR_HW_VERSION
@@ -12,14 +19,17 @@
 #ifndef MINOR_HW_VERSION
 #define MINOR_HW_VERSION 0
 #endif
+#ifndef PATCH_HW_VERSION
+#define PATCH_HW_VERSION 0
+#endif
 #ifndef MAJOR_FW_VERSION
 #define MAJOR_FW_VERSION 0
 #endif
 #ifndef MINOR_FW_VERSION
 #define MINOR_FW_VERSION 1
 #endif
-#ifndef ASSEMBLY_VERSION
-#define ASSEMBLY_VERSION 0
+#ifndef PATCH_FW_VERSION
+#define PATCH_FW_VERSION 0
 #endif
 
 


### PR DESCRIPTION
Allows compliance with device interface to be validated exclusively by regenerating header files, rather than overwriting implementation stubs.

Compliance with protocol V2 is also ensured by calling `core_func_start_core_V2` function with all required version parameters.