### PR TITLE
Fix handling of acronym prefixes in firmware naming convention

### DIFF
--- a/src/Firmware.cs
+++ b/src/Firmware.cs
@@ -396,6 +396,9 @@ public sealed class FirmwareNamingConvention : INamingConvention
         var startIndex = 0;
         while (startIndex < value.Length && (char.IsUpper(value[startIndex]) || !char.IsLetter(value[startIndex])))
         {
+            if (startIndex > 1 && (startIndex + 1) < value.Length &&
+                char.IsLetter(value[startIndex + 1]) && char.IsLower(value[startIndex + 1]))
+                break;
             startIndex++;
         }
 

--- a/tests/ExpectedOutput/device.app_ios_and_regs.h
+++ b/tests/ExpectedOutput/device.app_ios_and_regs.h
@@ -173,14 +173,18 @@ typedef struct
 /************************************************************************/
 /* Registers' bits                                                      */
 /************************************************************************/
-#define B_DIO0              (1<<0)       // 
-#define B_DIO1              (1<<1)       // 
-#define B_DIO2              (1<<2)       // 
-#define B_DIO3              (1<<10)      // 
-#define MSK_PWM_PORT_SEL    0x0F         // 
-#define GM_PWM_PORT_PWM0    0x01         // 
-#define GM_PWM_PORT_PWM1    0x02         // 
-#define GM_PWM_PORT_PWM2    0x04         // 
-#define GM_PWM_PORT_PWM3    0x0A         // 
+#define B_DIO0               (1<<0)       // 
+#define B_DIO1               (1<<1)       // 
+#define B_DIO2               (1<<2)       // 
+#define B_DIO3               (1<<3)       // 
+#define B_DI_PORT0           (1<<8)       // 
+#define B_TEST_DI_PORT1      (1<<9)       // 
+#define B_SUPPLY_PORT0       (1<<10)      // 
+#define B_PORT_DIO1          (1<<11)      // 
+#define MSK_PWM_PORT_SEL     0x0F         // 
+#define GM_PWM_PORT_PWM0     0x01         // 
+#define GM_PWM_PORT_PWM1     0x02         // 
+#define GM_PWM_PORT_PWM2     0x04         // 
+#define GM_PWM_PORT_PWM3     0x0A         // 
 
 #endif /* _APP_REGS_H_ */

--- a/tests/ExpectedOutput/device.cs
+++ b/tests/ExpectedOutput/device.cs
@@ -3293,7 +3293,11 @@ namespace Harp.Generators.Tests
         DIO0 = 0x1,
         DIO1 = 0x2,
         DIO2 = 0x4,
-        DIO3 = 0x400
+        DIO3 = 0x8,
+        DIPort0 = 0x100,
+        TestDIPort1 = 0x200,
+        SupplyPort0 = 0x400,
+        PortDIO1 = 0x800
     }
 
     /// <summary>

--- a/tests/Metadata/device.yml
+++ b/tests/Metadata/device.yml
@@ -164,7 +164,11 @@ bitMasks:
       DIO0: 0x1
       DIO1: 0x2
       DIO2: 0x4
-      DIO3: 0x400
+      DIO3: 0x8
+      DIPort0: 0x100
+      TestDIPort1: 0x200
+      SupplyPort0: 0x400
+      PortDIO1: 0x800
 groupMasks:
   PwmPort:
     values:


### PR DESCRIPTION
In this case we need to escape from early scanning so we do not accidentally merge two separate words.