### PR TITLE
Right-align register addresses in firmware header

### DIFF
--- a/src/AppRegs.tt
+++ b/src/AppRegs.tt
@@ -132,12 +132,13 @@ foreach (var registerMetadata in DeviceMetadata.Registers)
 foreach (var registerMetadata in DeviceMetadata.Registers)
 {
     var register = registerMetadata.Value;
+    var registerAddress = register.Address.ToString();
     var registerName = FirmwareNamingConvention.Instance.Apply(registerMetadata.Key);
     var registerType = TemplateHelper.GetFirmwareRegisterType(register.Type);
-    var addressOffset = new string(' ', maxRegisterNameLength - registerName.Length + 4);
+    var addressOffset = new string(' ', maxRegisterNameLength - registerName.Length - registerAddress.Length + 6);
     var descriptionOffset = new string(' ', 7 - registerType.Length);
 #>
-#define ADD_REG_<#= registerName #><#= addressOffset #><#= register.Address #> // <#= registerType #><#= descriptionOffset #><#= register.Description #>
+#define ADD_REG_<#= registerName #><#= addressOffset #><#= registerAddress #> // <#= registerType #><#= descriptionOffset #><#= register.Description #>
 <#
 }
 #>

--- a/tests/ExpectedOutput/device.app_ios_and_regs.h
+++ b/tests/ExpectedOutput/device.app_ios_and_regs.h
@@ -156,8 +156,8 @@ typedef struct
 #define ADD_REG_PORT_DIO_SET               41 // U8     
 #define ADD_REG_PULSE_DO_PORT0             42 // U16    
 #define ADD_REG_PULSE_DO0                  43 // U16    
-#define ADD_REG_START_PULSE                37 // U16    
-#define ADD_REG_START_PULSE_TRAIN          38 // U16    
+#define ADD_REG_START_PULSE               100 // U16    Starts a PWM pulse.
+#define ADD_REG_START_PULSE_TRAIN         101 // U16    Starts a PWM pulse train.
 
 /************************************************************************/
 /* Tests registers' memory limits                                       */
@@ -167,7 +167,7 @@ typedef struct
 /************************************************************************/
 /* Memory limits */
 #define APP_REGS_ADD_MIN                    0x20
-#define APP_REGS_ADD_MAX                    0x2B
+#define APP_REGS_ADD_MAX                    0x65
 #define APP_NBYTES_OF_REG_BANK              117
 
 /************************************************************************/

--- a/tests/ExpectedOutput/device.cs
+++ b/tests/ExpectedOutput/device.cs
@@ -49,8 +49,8 @@ namespace Harp.Generators.Tests
             { 41, typeof(PortDIOSet) },
             { 42, typeof(PulseDOPort0) },
             { 43, typeof(PulseDO0) },
-            { 37, typeof(StartPulse) },
-            { 38, typeof(StartPulseTrain) }
+            { 100, typeof(StartPulse) },
+            { 101, typeof(StartPulseTrain) }
         };
 
         /// <summary>
@@ -1693,15 +1693,15 @@ namespace Harp.Generators.Tests
     }
 
     /// <summary>
-    /// Represents a register that manipulates messages from register StartPulse.
+    /// Represents a register that starts a PWM pulse.
     /// </summary>
-    [Description("")]
+    [Description("Starts a PWM pulse.")]
     public partial class StartPulse
     {
         /// <summary>
         /// Represents the address of the <see cref="StartPulse"/> register. This field is constant.
         /// </summary>
-        public const int Address = 37;
+        public const int Address = 100;
 
         /// <summary>
         /// Represents the payload type of the <see cref="StartPulse"/> register. This field is constant.
@@ -1806,15 +1806,15 @@ namespace Harp.Generators.Tests
     }
 
     /// <summary>
-    /// Represents a register that manipulates messages from register StartPulseTrain.
+    /// Represents a register that starts a PWM pulse train.
     /// </summary>
-    [Description("")]
+    [Description("Starts a PWM pulse train.")]
     public partial class StartPulseTrain
     {
         /// <summary>
         /// Represents the address of the <see cref="StartPulseTrain"/> register. This field is constant.
         /// </summary>
-        public const int Address = 38;
+        public const int Address = 101;
 
         /// <summary>
         /// Represents the payload type of the <see cref="StartPulseTrain"/> register. This field is constant.
@@ -2738,10 +2738,10 @@ namespace Harp.Generators.Tests
 
     /// <summary>
     /// Represents an operator that creates a message payload
-    /// for register StartPulse.
+    /// that starts a PWM pulse.
     /// </summary>
     [DisplayName("StartPulsePayload")]
-    [Description("Creates a message payload for register StartPulse.")]
+    [Description("Creates a message payload that starts a PWM pulse.")]
     public partial class CreateStartPulsePayload
     {
         /// <summary>
@@ -2769,7 +2769,7 @@ namespace Harp.Generators.Tests
         }
 
         /// <summary>
-        /// Creates a message for register StartPulse.
+        /// Creates a message that starts a PWM pulse.
         /// </summary>
         /// <param name="messageType">Specifies the type of the created message.</param>
         /// <returns>A new message for the StartPulse register.</returns>
@@ -2781,14 +2781,14 @@ namespace Harp.Generators.Tests
 
     /// <summary>
     /// Represents an operator that creates a timestamped message payload
-    /// for register StartPulse.
+    /// that starts a PWM pulse.
     /// </summary>
     [DisplayName("TimestampedStartPulsePayload")]
-    [Description("Creates a timestamped message payload for register StartPulse.")]
+    [Description("Creates a timestamped message payload that starts a PWM pulse.")]
     public partial class CreateTimestampedStartPulsePayload : CreateStartPulsePayload
     {
         /// <summary>
-        /// Creates a timestamped message for register StartPulse.
+        /// Creates a timestamped message that starts a PWM pulse.
         /// </summary>
         /// <param name="timestamp">The timestamp of the message payload, in seconds.</param>
         /// <param name="messageType">Specifies the type of the created message.</param>
@@ -2801,10 +2801,10 @@ namespace Harp.Generators.Tests
 
     /// <summary>
     /// Represents an operator that creates a message payload
-    /// for register StartPulseTrain.
+    /// that starts a PWM pulse train.
     /// </summary>
     [DisplayName("StartPulseTrainPayload")]
-    [Description("Creates a message payload for register StartPulseTrain.")]
+    [Description("Creates a message payload that starts a PWM pulse train.")]
     public partial class CreateStartPulseTrainPayload
     {
         /// <summary>
@@ -2848,7 +2848,7 @@ namespace Harp.Generators.Tests
         }
 
         /// <summary>
-        /// Creates a message for register StartPulseTrain.
+        /// Creates a message that starts a PWM pulse train.
         /// </summary>
         /// <param name="messageType">Specifies the type of the created message.</param>
         /// <returns>A new message for the StartPulseTrain register.</returns>
@@ -2860,14 +2860,14 @@ namespace Harp.Generators.Tests
 
     /// <summary>
     /// Represents an operator that creates a timestamped message payload
-    /// for register StartPulseTrain.
+    /// that starts a PWM pulse train.
     /// </summary>
     [DisplayName("TimestampedStartPulseTrainPayload")]
-    [Description("Creates a timestamped message payload for register StartPulseTrain.")]
+    [Description("Creates a timestamped message payload that starts a PWM pulse train.")]
     public partial class CreateTimestampedStartPulseTrainPayload : CreateStartPulseTrainPayload
     {
         /// <summary>
-        /// Creates a timestamped message for register StartPulseTrain.
+        /// Creates a timestamped message that starts a PWM pulse train.
         /// </summary>
         /// <param name="timestamp">The timestamp of the message payload, in seconds.</param>
         /// <param name="messageType">Specifies the type of the created message.</param>

--- a/tests/Metadata/device.yml
+++ b/tests/Metadata/device.yml
@@ -128,9 +128,10 @@ registers:
     <<: *pulseDO
     address: 43
   StartPulse:
-    address: 37
+    address: 100
     type: U16
     access: Write
+    description: Starts a PWM pulse.
     payloadSpec: &startPulse
       DigitalOutput:
         offset: 0
@@ -141,10 +142,11 @@ registers:
         mask: 0x3FF
         interfaceType: ushort
   StartPulseTrain:
-    address: 38
+    address: 101
     type: U16
     length: 2
     access: Write
+    description: Starts a PWM pulse train.
     payloadSpec:
       <<: *startPulse
       Frequency:


### PR DESCRIPTION
Accounts for variable number of characters in address field. Also added regression testing for description strings to future-proof alignment of comments.