### PR TITLE
Remove redundant _SEL suffix

### DIFF
--- a/src/AppRegs.tt
+++ b/src/AppRegs.tt
@@ -183,10 +183,10 @@ foreach (var groupMask in DeviceMetadata.GroupMasks)
     var mask = groupMask.Value;
     var maskSelect = TemplateHelper.GetMaskSelect(mask).ToString("X2");
     var maskName = TemplateHelper.GetFirmwareGroupMaskName(groupMask.Key);
-    var maskNamePadding = new string(' ', maxMaskNameLength - maskName.Length);
+    var maskNamePadding = new string(' ', maxMaskNameLength - maskName.Length + 4);
     var maskSelectPadding = new string(' ', 11 - maskSelect.Length);
 #>
-#define MSK_<#= maskName #>_SEL<#= maskNamePadding #>0x<#= maskSelect #><#= maskSelectPadding #>// 
+#define MSK_<#= maskName #><#= maskNamePadding #>0x<#= maskSelect #><#= maskSelectPadding #>// 
 <#
 
     foreach (var member in mask.Values)

--- a/tests/ExpectedOutput/device.app_ios_and_regs.h
+++ b/tests/ExpectedOutput/device.app_ios_and_regs.h
@@ -190,12 +190,12 @@ typedef struct
 #define B_TEST_DI_PORT1                 (1<<9)       // 
 #define B_SUPPLY_PORT0                  (1<<10)      // 
 #define B_PORT_DIO1                     (1<<11)      // 
-#define MSK_PWM_PORT_SEL                0x0F         // 
+#define MSK_PWM_PORT                    0x0F         // 
 #define GM_PWM_PORT_PWM0                0x01         // 
 #define GM_PWM_PORT_PWM1                0x02         // 
 #define GM_PWM_PORT_PWM2                0x04         // 
 #define GM_PWM_PORT_PWM3                0x0A         // 
-#define MSK_ENCODER_MODE_SEL            0x01         // 
+#define MSK_ENCODER_MODE                0x01         // 
 #define GM_ENCODER_MODE_POSITION        0x00         // 
 #define GM_ENCODER_MODE_DISPLACEMENT    0x01         // 
 


### PR DESCRIPTION
The group mask selection name is already unique from the MSK_ prefix so there is no need to add a further qualifier.