### PR TITLE
Make payload member length non-nullable

### DIFF
--- a/src/Interface.cs
+++ b/src/Interface.cs
@@ -223,7 +223,7 @@ public class PayloadMemberInfo
     /// <summary>
     /// Specifies the number of elements used to encode this payload member.
     /// </summary>
-    public int? Length;
+    public int Length;
 
     /// <summary>
     /// Specifies the mask used to read and write this payload member.
@@ -287,10 +287,10 @@ public class PayloadMemberInfo
         return Converter switch
         {
             MemberConverter.RawPayload => "ArraySegment<byte>",
-            MemberConverter.Payload => Length.GetValueOrDefault() > 0
+            MemberConverter.Payload => Length > 0
                 ? $"ArraySegment<{TemplateHelper.GetInterfaceType(payloadType, 0)}>"
                 : TemplateHelper.GetInterfaceType(payloadType, 0),
-            _ => TemplateHelper.GetInterfaceType(payloadType, Length.GetValueOrDefault())
+            _ => TemplateHelper.GetInterfaceType(payloadType, Length)
         };
     }
 }
@@ -384,7 +384,7 @@ internal static partial class TemplateHelper
     {
         if (!string.IsNullOrEmpty(member.InterfaceType)) return member.InterfaceType;
         else if (!string.IsNullOrEmpty(member.MaskType)) return member.MaskType;
-        else return GetInterfaceType(payloadType, member.Length.GetValueOrDefault());
+        else return GetInterfaceType(payloadType, member.Length);
     }
 
     public static string GetInterfaceType(PayloadType payloadType)
@@ -570,7 +570,7 @@ internal static partial class TemplateHelper
         DeviceInfo deviceMetadata)
     {
         var payloadType = register.Type;
-        var memberLength = member.Length.GetValueOrDefault();
+        var memberLength = member.Length;
         var memberOffset = member.Offset.GetValueOrDefault();
         var payloadInterfaceType = GetInterfaceType(payloadType);
         if (memberLength > 0 && member.InterfaceType != "bool")
@@ -636,7 +636,7 @@ internal static partial class TemplateHelper
         bool assigned)
     {
         var payloadType = register.Type;
-        var memberLength = member.Length.GetValueOrDefault();
+        var memberLength = member.Length;
         var memberOffset = member.Offset.GetValueOrDefault();
         var payloadInterfaceType = GetInterfaceType(payloadType);
 

--- a/src/Python.cs
+++ b/src/Python.cs
@@ -427,7 +427,7 @@ internal static partial class TemplateHelper
         }
 
         module.ProtocolImports.Add("Field");
-        var memberLength = member.Length.GetValueOrDefault(0);
+        var memberLength = member.Length;
         var span = Math.Max(1, memberLength) * elementSize;
 
         if (member.InterfaceType == "string")
@@ -524,7 +524,7 @@ internal static partial class TemplateHelper
     static string GetPythonDefaultArgument(PayloadMemberInfo member, string typeName, RegisterInfo register, DeviceInfo deviceMetadata)
     {
         var defaultValue = member.DefaultValue ?? member.MinValue;
-        if (!defaultValue.HasValue || member.Length.GetValueOrDefault() > 1)
+        if (!defaultValue.HasValue || member.Length > 1)
             return string.Empty;
 
         var value = defaultValue.GetValueOrDefault();

--- a/tests/PythonInteropTests.cs
+++ b/tests/PythonInteropTests.cs
@@ -131,10 +131,10 @@ static class InteropValue
     static object BuildField(Type fieldType, PayloadMemberInfo member, int seed)
     {
         if (fieldType.IsArray)
-            return BuildArray(fieldType.GetElementType()!, member.Length.GetValueOrDefault(1), seed);
+            return BuildArray(fieldType.GetElementType()!, Math.Max(1, member.Length), seed);
         if (fieldType.IsEnum)
             return SmallestFittingEnumValue(fieldType, GetFieldRange(member));
-        return BuildScalar(fieldType, member.Length.GetValueOrDefault(1), GetFieldRange(member), seed);
+        return BuildScalar(fieldType, Math.Max(1, member.Length), GetFieldRange(member), seed);
     }
 
     static long GetElementRange(PayloadType payloadType)


### PR DESCRIPTION
The payload member length is now declared as an `int`, matching the register length. A member declaring no length continues to mean a single element.

C#, Python and firmware interfaces generate every expected output file exactly as before. The round-trip serializer test also passes unchanged, since a zero `int` is omitted from written YAML under `OmitDefaults` exactly as a null is under `OmitNull`.

`PayloadMemberInfo.Length` changes the type of a public field, so anything reading it directly is affected. `RegisterInfo.Length` is unaffected, having always been an `int`.

## Notes for review

`Offset` stays nullable. `member.Offset.HasValue` decides whether a member of an array register is indexed, and an offset of zero is both legal and common, so absence and zero must stay distinct there.

Closes #125