### PR TITLE
Emit ArrayConverter for array payload members

### DIFF
--- a/src/Python.cs
+++ b/src/Python.cs
@@ -454,18 +454,19 @@ internal static partial class TemplateHelper
 
         if (string.IsNullOrEmpty(member.InterfaceType))
         {
-            module.ProtocolImports.Add("IdentityConverter");
             if (memberLength > 0)
             {
+                module.ProtocolImports.Add("ArrayConverter");
                 module.UsesNDArray = true;
                 return new PythonField
                 {
                     Name = name,
                     Annotation = $"NDArray[{elementType}]",
-                    Descriptor = $"Field(IdentityConverter(np.dtype(({elementType}, ({memberLength},)))){offsetArgument}{defaultArgument})"
+                    Descriptor = $"Field(ArrayConverter({elementType}, {memberLength}){offsetArgument}{defaultArgument})"
                 };
             }
 
+            module.ProtocolImports.Add("IdentityConverter");
             return new PythonField
             {
                 Name = name,

--- a/tests/ExpectedOutput/device.py
+++ b/tests/ExpectedOutput/device.py
@@ -8,6 +8,7 @@ import numpy as np
 from numpy.typing import NDArray
 from harp.protocol import (
     AnonymousPayload,
+    ArrayConverter,
     BitMask,
     BoolConverter,
     Field,
@@ -105,7 +106,7 @@ class AnalogDataPayload(StructPayload[np.float32], length=6):
     analog0: np.float32 = Field(IdentityConverter(np.float32))
     analog1: np.float32 = Field(IdentityConverter(np.float32), offset=1)
     analog2: np.float32 = Field(IdentityConverter(np.float32), offset=2)
-    accelerometer: NDArray[np.float32] = Field(IdentityConverter(np.dtype((np.float32, (3,)))), offset=3)
+    accelerometer: NDArray[np.float32] = Field(ArrayConverter(np.float32, 3), offset=3)
 
 
 class ComplexConfigurationPayload(StructPayload[np.uint8], length=17):
@@ -125,7 +126,7 @@ class VersionPayload(StructPayload[np.uint8], length=32):
     firmware_version: HarpVersion = Field(HarpVersionConverter(np.uint8), offset=3)
     hardware_version: HarpVersion = Field(HarpVersionConverter(np.uint8), offset=6)
     core_id: str = Field(StringConverter(3), offset=9)
-    interface_hash: NDArray[np.uint8] = Field(IdentityConverter(np.dtype((np.uint8, (20,)))), offset=12)
+    interface_hash: NDArray[np.uint8] = Field(ArrayConverter(np.uint8, 20), offset=12)
 
 
 class CustomPayloadPayload(AnonymousPayload[np.uint32]):
@@ -164,8 +165,8 @@ class MixedMemberLengthPayload(StructPayload[np.uint8], length=4):
     """Represents the payload of the MixedMemberLength register."""
 
     absent: np.uint8 = Field(IdentityConverter(np.uint8))
-    single: NDArray[np.uint8] = Field(IdentityConverter(np.dtype((np.uint8, (1,)))), offset=1)
-    multiple: NDArray[np.uint8] = Field(IdentityConverter(np.dtype((np.uint8, (2,)))), offset=2)
+    single: NDArray[np.uint8] = Field(ArrayConverter(np.uint8, 1), offset=1)
+    multiple: NDArray[np.uint8] = Field(ArrayConverter(np.uint8, 2), offset=2)
 
 
 class StartPulsePayload(StructPayload[np.uint16]):


### PR DESCRIPTION
An array payload member now generates `ArrayConverter` over the element type and its count, as in `Field(ArrayConverter(np.float32, 3), offset=3)`, so the generated module type-checks.

Decoding is unchanged. `ArrayConverter` builds an `IdentityConverter` over the equivalent sub-array dtype, so the runtime object is the same one it was before and the cross-stack interop test passes without modification.

## Notes for review

The `IdentityConverter` import now belongs to the scalar path alone, so a module whose only passthrough member is an array no longer declares an import it does not use. That has no effect on the expected output here, which has scalar members too, but it matters for device repositories that lint generated code.

`core.py` and `device.coremasks.py` are unchanged, since neither declares an array payload member. `device.py` is the only expected output affected, at one import and four descriptors.

Closes #123
