### PR TITLE
Make the generated Python type-check

### DIFF
--- a/.github/workflows/Harp.Generators.yml
+++ b/.github/workflows/Harp.Generators.yml
@@ -105,6 +105,10 @@ jobs:
           HARP_INTEROP_OUTPUT: ${{github.workspace}}/artifacts/python-interop
         run: uv run --project tests/Python pytest tests/Python/test_interop.py
 
+      - name: Type-check generated Python
+        if: matrix.configuration == 'release'
+        run: uv run --project tests/Python pyright artifacts/python-interop/harp_device
+
       # ----------------------------------------------------------------------- Collect artifacts
       - name: Collect NuGet packages
         uses: actions/upload-artifact@v4

--- a/src/PyDevice.tt
+++ b/src/PyDevice.tt
@@ -230,7 +230,7 @@ class <#= register.Name #>(<#= register.BaseClass #>):
     if (register.Kind == PythonRegisterKind.Array)
     {
 #>
-    length: ClassVar[int] = <#= register.Length #>
+    length: int = <#= register.Length #>
 <#
     }
     else if (register.Kind == PythonRegisterKind.Struct)

--- a/tests/ExpectedOutput/device.py
+++ b/tests/ExpectedOutput/device.py
@@ -257,12 +257,12 @@ class PulseDO0(RegisterU16):
 
 class MultiElementPayload(RegisterU16Array):
     address: ClassVar[int] = 44
-    length: ClassVar[int] = 3
+    length: int = 3
 
 
 class SingleElementPayload(RegisterU16Array):
     address: ClassVar[int] = 45
-    length: ClassVar[int] = 1
+    length: int = 1
 
 
 class MixedMemberLength(RegisterBase[MixedMemberLengthPayload]):

--- a/tests/Python/converters.py
+++ b/tests/Python/converters.py
@@ -14,8 +14,8 @@ from numpy.typing import NDArray
 from harp.protocol import Converter
 
 
-class DataConverter(Converter[int]):
-    """Maps two raw little-endian signed bytes to and from a Python int.
+class DataConverter(Converter[np.int32]):
+    """Maps two raw little-endian signed bytes to and from a numpy int32.
 
     Models interfaceType: int over a two-byte sub-region of the CustomMemberConverter payload.
     """
@@ -26,8 +26,8 @@ class DataConverter(Converter[int]):
         self._length = 2
         self.dtype = np.dtype((np.uint8, (self._length,)))
 
-    def decode_scalar(self, view: np.generic) -> int:
-        return int.from_bytes(bytes(np.asarray(view).tolist()), "little", signed=True)
+    def decode_scalar(self, view: np.generic) -> np.int32:
+        return np.int32(int.from_bytes(bytes(np.asarray(view).tolist()), "little", signed=True))
 
     def decode_batch(self, view: NDArray[np.generic]) -> Any:
         return np.array(
@@ -35,7 +35,7 @@ class DataConverter(Converter[int]):
             dtype=object,
         )
 
-    def encode_into(self, view: NDArray[np.generic], value: int) -> None:
+    def encode_into(self, view: NDArray[np.generic], value: np.int32) -> None:
         view[...] = np.frombuffer(
             int(value).to_bytes(self._length, "little", signed=True), dtype=np.uint8
         )

--- a/tests/Python/pyproject.toml
+++ b/tests/Python/pyproject.toml
@@ -6,5 +6,6 @@ requires-python = ">=3.11"
 dependencies = [
     "harp-protocol>=0.5.0",
     "harp-device>=0.5.0",
+    "pyright>=1.1.411",
     "pytest>=8",
 ]


### PR DESCRIPTION
An array register declares `length` as a plain annotation, and the example converter presents the type the schema promises.

## Array register length

`length` is declared in the body of the metaclass that owns array registers, so each register class carries its own value. Annotating it `ClassVar` in a generated class body claims instead that the attribute is shared across every register class, which is not what it means.

`address` keeps its `ClassVar`, because `RegisterBase` is an ordinary class and declares it that way. Both annotations end up describing an attribute on the register class, and they differ only because one arrives through the class and the other through its metaclass.

## Example converter

`DataConverter` in the interop project now uses `np.int32` rather than a Python `int`. An `interfaceType` of `int` maps to `np.int32` throughout the Python target, which is also the annotation the generator emits beside the field, so the hand-written converter was the side that disagreed.

## Type-checking in CI

pyright runs over the generated device package after the interop test, against the package that test already assembles, so it is always the module the generator has just produced and there is nothing to keep in step by hand.

pyright is declared in the interop project rather than installed for the step alone, so a local run matches CI. Its floor matches the one harp-tech/python declares for its own checks.