### PR TITLE
Rename DeviceInfo to DeviceMetadata

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -38,7 +38,7 @@ A complete reactive interface to communicate with the device can be generated fr
 ```csharp
 using var reader = new StreamReader("device.yml");
 var parser = new MergingParser(new Parser(reader));
-var deviceMetadata = MetadataDeserializer.Instance.Deserialize<DeviceInfo>(parser);
+var deviceMetadata = MetadataDeserializer.Instance.Deserialize<DeviceMetadata>(parser);
 
 var generator = new InterfaceGenerator(deviceMetadata, "MyNamespace");
 var implementation = generator.GenerateImplementation();

--- a/src/App.tt
+++ b/src/App.tt
@@ -1,5 +1,5 @@
 ﻿<#@ template debug="true" hostspecific="false" visibility="internal" language="C#" inherits="TemplateBase" #>
-<#@ parameter name="DeviceMetadata" type="DeviceInfo" #>
+<#@ parameter name="DeviceMetadata" type="DeviceMetadata" #>
 <#@ import namespace="Harp.Generators" #>
 <#@ import namespace="System.IO" #>
 <#@ output extension=".h" #>

--- a/src/AppFuncs.tt
+++ b/src/AppFuncs.tt
@@ -1,5 +1,5 @@
 ﻿<#@ template debug="true" hostspecific="false" visibility="internal" language="C#" inherits="TemplateBase" #>
-<#@ parameter name="DeviceMetadata" type="DeviceInfo" #>
+<#@ parameter name="DeviceMetadata" type="DeviceMetadata" #>
 <#@ import namespace="Harp.Generators" #>
 <#@ import namespace="System.IO" #>
 <#@ import namespace="System.Linq" #>

--- a/src/AppFuncsImpl.tt
+++ b/src/AppFuncsImpl.tt
@@ -1,5 +1,5 @@
 ﻿<#@ template debug="true" hostspecific="false" visibility="internal" language="C#" inherits="TemplateBase" #>
-<#@ parameter name="DeviceMetadata" type="DeviceInfo" #>
+<#@ parameter name="DeviceMetadata" type="DeviceMetadata" #>
 <#@ import namespace="Harp.Generators" #>
 <#@ import namespace="System.IO" #>
 <#@ import namespace="System.Linq" #>

--- a/src/AppImpl.tt
+++ b/src/AppImpl.tt
@@ -1,5 +1,5 @@
 ﻿<#@ template debug="true" hostspecific="false" visibility="internal" language="C#" inherits="TemplateBase" #>
-<#@ parameter name="DeviceMetadata" type="DeviceInfo" #>
+<#@ parameter name="DeviceMetadata" type="DeviceMetadata" #>
 <#@ import namespace="Harp.Generators" #>
 <#@ import namespace="System.IO" #>
 <#@ output extension=".c" #>

--- a/src/AppRegs.tt
+++ b/src/AppRegs.tt
@@ -1,5 +1,5 @@
 ﻿<#@ template debug="true" hostspecific="false" visibility="internal" language="C#" inherits="TemplateBase" #>
-<#@ parameter name="DeviceMetadata" type="DeviceInfo" #>
+<#@ parameter name="DeviceMetadata" type="DeviceMetadata" #>
 <#@ parameter name="PortPinMetadata" type="Dictionary<string, PortPinInfo>" #>
 <#@ import namespace="Harp.Generators" #>
 <#@ import namespace="System.IO" #>

--- a/src/AppRegsImpl.tt
+++ b/src/AppRegsImpl.tt
@@ -1,5 +1,5 @@
 ﻿<#@ template debug="true" hostspecific="false" visibility="internal" language="C#" inherits="TemplateBase" #>
-<#@ parameter name="DeviceMetadata" type="DeviceInfo" #>
+<#@ parameter name="DeviceMetadata" type="DeviceMetadata" #>
 <#@ parameter name="PortPinMetadata" type="Dictionary<string, PortPinInfo>" #>
 <#@ import namespace="Harp.Generators" #>
 <#@ import namespace="System.IO" #>

--- a/src/AsyncDevice.tt
+++ b/src/AsyncDevice.tt
@@ -1,6 +1,6 @@
 ﻿<#@ template debug="true" hostspecific="false" visibility="internal" language="C#" inherits="TemplateBase" #>
 <#@ parameter name="Namespace" type="string" #>
-<#@ parameter name="DeviceMetadata" type="DeviceInfo" #>
+<#@ parameter name="DeviceMetadata" type="DeviceMetadata" #>
 <#@ import namespace="Harp.Generators" #>
 <#@ import namespace="System.IO" #>
 <#@ import namespace="System.Linq" #>

--- a/src/Device.tt
+++ b/src/Device.tt
@@ -1,6 +1,6 @@
 ﻿<#@ template debug="true" hostspecific="false" visibility="internal" language="C#" inherits="TemplateBase" #>
 <#@ parameter name="Namespace" type="string" #>
-<#@ parameter name="DeviceMetadata" type="DeviceInfo" #>
+<#@ parameter name="DeviceMetadata" type="DeviceMetadata" #>
 <#@ import namespace="YamlDotNet.Serialization.NamingConventions" #>
 <#@ import namespace="Harp.Generators" #>
 <#@ import namespace="System.IO" #>

--- a/src/Firmware.cs
+++ b/src/Firmware.cs
@@ -296,7 +296,7 @@ internal static partial class TemplateHelper
         return GetFirmwareName(value);
     }
 
-    public static int GetMaxFirmwareBitMaskNameLength(DeviceInfo deviceMetadata)
+    public static int GetMaxFirmwareBitMaskNameLength(DeviceMetadata deviceMetadata)
     {
         return deviceMetadata.BitMasks.Values
             .SelectMany(mask => mask.Bits)
@@ -304,7 +304,7 @@ internal static partial class TemplateHelper
             .Prepend(0).Max();
     }
 
-    public static int GetMaxFirmwareGroupMaskNameLength(DeviceInfo deviceMetadata)
+    public static int GetMaxFirmwareGroupMaskNameLength(DeviceMetadata deviceMetadata)
     {
         return (from groupMask in deviceMetadata.GroupMasks
                 let maskName = GetFirmwareGroupMaskName(groupMask.Key)

--- a/src/FirmwareGenerator.cs
+++ b/src/FirmwareGenerator.cs
@@ -24,7 +24,7 @@ public class FirmwareGenerator
     /// </summary>
     /// <param name="deviceMetadata">The device metadata object.</param>
     /// <param name="portPinMetadata">The IO pin configuration map.</param>
-    public FirmwareGenerator(DeviceInfo deviceMetadata, Dictionary<string, PortPinInfo> portPinMetadata)
+    public FirmwareGenerator(DeviceMetadata deviceMetadata, Dictionary<string, PortPinInfo> portPinMetadata)
     {
         var session = new Dictionary<string, object>
         {

--- a/src/Interface.cs
+++ b/src/Interface.cs
@@ -11,9 +11,9 @@ using YamlDotNet.Serialization.NamingConventions;
 namespace Harp.Generators;
 
 /// <summary>
-/// Represents information about Harp device functionality and operation registers.
+/// Represents metadata about Harp device functionality and operation registers.
 /// </summary>
-public class DeviceInfo
+public class DeviceMetadata
 {
     /// <summary>
     /// Specifies a summary description of the register interface.
@@ -360,16 +360,16 @@ public class MaskValue
 
 internal static partial class TemplateHelper
 {
-    public static DeviceInfo ReadDeviceMetadata(string path)
+    public static DeviceMetadata ReadDeviceMetadata(string path)
     {
         using var reader = new StreamReader(path);
         return ReadDeviceMetadata(reader);
     }
 
-    public static DeviceInfo ReadDeviceMetadata(TextReader reader)
+    public static DeviceMetadata ReadDeviceMetadata(TextReader reader)
     {
         var parser = new MergingParser(new Parser(reader));
-        return MetadataDeserializer.Instance.Deserialize<DeviceInfo>(parser);
+        return MetadataDeserializer.Instance.Deserialize<DeviceMetadata>(parser);
     }
 
     public static string GetInterfaceType(string name, RegisterInfo register)
@@ -546,7 +546,7 @@ internal static partial class TemplateHelper
     static int GetMemberSize(
         PayloadMemberInfo member,
         RegisterInfo register,
-        DeviceInfo deviceMetadata,
+        DeviceMetadata deviceMetadata,
         out string interfaceType,
         out PayloadType payloadType)
     {
@@ -567,7 +567,7 @@ internal static partial class TemplateHelper
         PayloadMemberInfo member,
         string expression,
         RegisterInfo register,
-        DeviceInfo deviceMetadata)
+        DeviceMetadata deviceMetadata)
     {
         var payloadType = register.Type;
         var memberLength = member.Length;

--- a/src/InterfaceGenerator.cs
+++ b/src/InterfaceGenerator.cs
@@ -19,7 +19,7 @@ public sealed class InterfaceGenerator
     /// </summary>
     /// <param name="deviceMetadata">The device metadata object.</param>
     /// <param name="ns">The target namespace to use for all generated code.</param>
-    public InterfaceGenerator(DeviceInfo deviceMetadata, string ns)
+    public InterfaceGenerator(DeviceMetadata deviceMetadata, string ns)
     {
         var session = new Dictionary<string, object>
         {

--- a/src/PyDevice.tt
+++ b/src/PyDevice.tt
@@ -1,5 +1,5 @@
 ﻿<#@ template debug="true" hostspecific="false" visibility="internal" language="C#" inherits="TemplateBase" #>
-<#@ parameter name="DeviceMetadata" type="DeviceInfo" #>
+<#@ parameter name="DeviceMetadata" type="DeviceMetadata" #>
 <#@ import namespace="Harp.Generators" #>
 <#@ import namespace="System.Linq" #>
 <#@ import namespace="System.Collections.Generic" #>

--- a/src/Python.cs
+++ b/src/Python.cs
@@ -104,7 +104,7 @@ internal static partial class TemplateHelper
 
     static readonly HashSet<string> StandardConverterInterfaceTypes = ["HarpVersion"];
 
-    static readonly Lazy<DeviceInfo> CoreMetadata = new(() =>
+    static readonly Lazy<DeviceMetadata> CoreMetadata = new(() =>
     {
         using var stream = typeof(TemplateHelper).Assembly.GetManifestResourceStream(CoreMetadataResourceName)
             ?? throw new InvalidOperationException($"Embedded metadata '{CoreMetadataResourceName}' was not found.");
@@ -112,21 +112,21 @@ internal static partial class TemplateHelper
         return ReadDeviceMetadata(reader);
     });
 
-    static GroupMaskInfo? FindGroupMask(DeviceInfo deviceMetadata, string typeName)
+    static GroupMaskInfo? FindGroupMask(DeviceMetadata deviceMetadata, string typeName)
     {
         if (deviceMetadata.GroupMasks.TryGetValue(typeName, out var groupMask)) return groupMask;
         if (deviceMetadata.BitMasks.ContainsKey(typeName)) return null;
         return CoreMetadata.Value.GroupMasks.TryGetValue(typeName, out groupMask) ? groupMask : null;
     }
 
-    static bool IsBitMask(DeviceInfo deviceMetadata, string typeName)
+    static bool IsBitMask(DeviceMetadata deviceMetadata, string typeName)
     {
         if (deviceMetadata.BitMasks.ContainsKey(typeName)) return true;
         if (deviceMetadata.GroupMasks.ContainsKey(typeName)) return false;
         return CoreMetadata.Value.BitMasks.ContainsKey(typeName);
     }
 
-    static void AddCoreImport(PythonModule module, DeviceInfo deviceMetadata, string typeName)
+    static void AddCoreImport(PythonModule module, DeviceMetadata deviceMetadata, string typeName)
     {
         if (!deviceMetadata.GroupMasks.ContainsKey(typeName) && !deviceMetadata.BitMasks.ContainsKey(typeName))
             module.CoreImports.Add(typeName);
@@ -197,7 +197,7 @@ internal static partial class TemplateHelper
         return FirmwareNamingConvention.Instance.Apply(name).ToLowerInvariant();
     }
 
-    public static PythonModule BuildPythonModule(DeviceInfo deviceMetadata)
+    public static PythonModule BuildPythonModule(DeviceMetadata deviceMetadata)
     {
         var module = new PythonModule
         {
@@ -237,7 +237,7 @@ internal static partial class TemplateHelper
         return pythonEnum;
     }
 
-    static void BuildPythonRegister(PythonModule module, string name, RegisterInfo register, DeviceInfo deviceMetadata)
+    static void BuildPythonRegister(PythonModule module, string name, RegisterInfo register, DeviceMetadata deviceMetadata)
     {
         var hasMask = !string.IsNullOrEmpty(register.MaskType);
         var isString = register.InterfaceType == "string";
@@ -287,7 +287,7 @@ internal static partial class TemplateHelper
         });
     }
 
-    static PythonPayload BuildPythonPayload(PythonModule module, string payloadName, RegisterInfo register, DeviceInfo deviceMetadata)
+    static PythonPayload BuildPythonPayload(PythonModule module, string payloadName, RegisterInfo register, DeviceMetadata deviceMetadata)
     {
         var elementType = GetPythonNumpyType(register.Type);
         var elementSize = GetPayloadTypeSize(register.Type);
@@ -375,7 +375,7 @@ internal static partial class TemplateHelper
         string name,
         PayloadMemberInfo member,
         RegisterInfo register,
-        DeviceInfo deviceMetadata,
+        DeviceMetadata deviceMetadata,
         string elementType,
         int elementSize)
     {
@@ -517,12 +517,7 @@ internal static partial class TemplateHelper
         return GetPythonNumpyType(register.Type);
     }
 
-    static string GetMemberAnnotation(PayloadMemberInfo member, RegisterInfo register)
-    {
-        return GetMemberNumpyType(member, register);
-    }
-
-    static string GetPythonDefaultArgument(PayloadMemberInfo member, string typeName, RegisterInfo register, DeviceInfo deviceMetadata)
+    static string GetPythonDefaultArgument(PayloadMemberInfo member, string typeName, RegisterInfo register, DeviceMetadata deviceMetadata)
     {
         var defaultValue = member.DefaultValue ?? member.MinValue;
         if (!defaultValue.HasValue || member.Length > 0)

--- a/src/PythonGenerator.cs
+++ b/src/PythonGenerator.cs
@@ -17,7 +17,7 @@ public sealed class PythonGenerator
     /// specified device metadata.
     /// </summary>
     /// <param name="deviceMetadata">The device metadata object.</param>
-    public PythonGenerator(DeviceInfo deviceMetadata)
+    public PythonGenerator(DeviceMetadata deviceMetadata)
     {
         var session = new Dictionary<string, object>
         {

--- a/tests/MetadataSerializerTests.cs
+++ b/tests/MetadataSerializerTests.cs
@@ -34,8 +34,8 @@ public sealed class MetadataSerializerTests
     }
 
     [DataTestMethod]
-    [DataRow("core.yml", typeof(DeviceInfo))]
-    [DataRow("device.yml", typeof(DeviceInfo))]
+    [DataRow("core.yml", typeof(DeviceMetadata))]
+    [DataRow("device.yml", typeof(DeviceMetadata))]
     [DataRow("device.ios.yml", typeof(Dictionary<string, PortPinInfo>))]
     public void Metadata_RoundTripSerializes(string metadataFileName, Type type)
     {

--- a/tests/TestHelper.cs
+++ b/tests/TestHelper.cs
@@ -29,11 +29,11 @@ static class TestHelper
         return Path.Combine("Metadata", fileName);
     }
 
-    public static DeviceInfo ReadDeviceMetadata(string path)
+    public static DeviceMetadata ReadDeviceMetadata(string path)
     {
         using var reader = new StreamReader(path);
         var parser = new MergingParser(new Parser(reader));
-        return MetadataDeserializer.Instance.Deserialize<DeviceInfo>(parser);
+        return MetadataDeserializer.Instance.Deserialize<DeviceMetadata>(parser);
     }
 
     public static Dictionary<string, PortPinInfo> ReadPortPinMetadata(string path)


### PR DESCRIPTION
The deserialized `device.yml` root is now `DeviceMetadata`. That is the name the codebase already gives it everywhere else: the reader is `ReadDeviceMetadata`, the round-trip pair is `MetadataDeserializer` and `MetadataSerializer`, every generator parameter is `deviceMetadata`, and all nine T4 templates bind the object as `DeviceMetadata`. One concept now travels under one word.

The sibling types keep their names. `RegisterInfo`, `BitMaskInfo`, `GroupMaskInfo`, `PayloadMemberInfo` and `PortPinInfo` are unchanged, following the shape reflection uses, where the entry point is `Type` with no suffix while the elements within it are `PropertyInfo`, `FieldInfo` and `MethodInfo`. The document root and the nodes inside it play different roles and read better under different names.

## Breaking change

`DeviceInfo` is a public type, so anything naming it needs updating. The rename is whole-word and total: no member, overload or file name changes with it, and the YAML contract is untouched, since deserialization maps on property names rather than on the root type name.

## Notes for review

Generated output is unchanged for every target. No expected output file moves, which is the check that the rename stays inside the model and never reaches emitted code.

Nine templates now read `<#@ parameter name="DeviceMetadata" type="DeviceMetadata" #>`, so the generated template property shares its type name. That is the "color color" case, which C# permits, and it compiles.

`GetMemberAnnotation` in `src/Python.cs` is deleted in passing. It forwarded to `GetMemberNumpyType` and was called from nowhere.

Closes #128
